### PR TITLE
Convert NativeSender from using WebRequest to HttpClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Debug
 Release
 bin
 obj
+.vs
 
 *.nupkg
 src/.idea/.idea.smartystreets-dotnet-sdk

--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +40,9 @@
       <Project>{3B3C4EEC-1F49-47F1-A531-6799BC5B66F8}</Project>
       <Name>SDK</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/IntegrationTests/app.config
+++ b/src/IntegrationTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/examples/Examples.csproj
+++ b/src/examples/Examples.csproj
@@ -56,5 +56,8 @@
       <Name>SDK</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/examples/app.config
+++ b/src/examples/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/sdk/NativeSender.cs
+++ b/src/sdk/NativeSender.cs
@@ -1,127 +1,94 @@
-﻿namespace SmartyStreets
+namespace SmartyStreets
 {
 	using System;
-	using System.IO;
 	using System.Net;
+	using System.Net.Http;
 
 	public class NativeSender : ISender
 	{
 		private static readonly Version AssemblyVersion = typeof(NativeSender).Assembly.GetName().Version;
 		private static readonly string UserAgent = string.Format("smartystreets (sdk:dotnet@{0}.{1}.{2})", AssemblyVersion.Major, AssemblyVersion.Minor, AssemblyVersion.Build);
-		private TimeSpan timeout;
-        private static Proxy SmartyProxy;
+		private HttpClient httpClient;
 
 		public NativeSender()
 		{
-			this.timeout = TimeSpan.FromSeconds(10);
+			BuildClient(TimeSpan.FromSeconds(10));
 		}
+
 		public NativeSender(TimeSpan timeout, Proxy proxy)
 		{
-			this.timeout = timeout;
-            SmartyProxy = proxy;
+			BuildClient(timeout, proxy);
 		}
 
 		public Response Send(Request request)
 		{
-			var frameworkRequest = this.BuildRequest(request);
-			CopyHeaders(request, frameworkRequest);
+			using (var frameworkRequest = BuildRequest(request)) {
+				CopyHeaders(request, frameworkRequest);
 
-			TryWritePayload(request, frameworkRequest);
+				TryWritePayload(request, frameworkRequest);
 
-			var frameworkResponse = GetResponse(frameworkRequest);
-			var statusCode = (int)frameworkResponse.StatusCode;
-			var payload = GetResponseBody(frameworkResponse);
+				using (var frameworkResponse = GetResponse(frameworkRequest)) {
+					var statusCode = (int)frameworkResponse.StatusCode;
+					var payload = GetResponseBody(frameworkResponse);
 
-			return new Response(statusCode, payload);
+					return new Response(statusCode, payload);
+				}
+			}
 		}
-		private HttpWebRequest BuildRequest(Request request)
-		{
-			var frameworkRequest = (HttpWebRequest)WebRequest.Create(request.GetUrl());
-			frameworkRequest.Timeout = (int)this.timeout.TotalMilliseconds;
-			frameworkRequest.Method = request.Method;
 
-            if (SmartyProxy != null)
-                SetProxy(frameworkRequest);
+		private void BuildClient(TimeSpan timeout, Proxy smartyProxy = null)
+		{
+			HttpClientHandler handler = null;
+			if (smartyProxy != null) {
+				handler = new HttpClientHandler();
+				var proxy = new WebProxy(smartyProxy.Address);
+
+				if (smartyProxy.Username != null && smartyProxy.Password != null) {
+					proxy.Credentials = new NetworkCredential(smartyProxy.Username, smartyProxy.Password);
+				}
+
+				handler.Proxy = proxy;
+				httpClient = new HttpClient(handler);
+			}
+			else {
+				httpClient = new HttpClient();
+			}
+			httpClient.Timeout = timeout;
+		}
+
+		private HttpRequestMessage BuildRequest(Request request)
+		{
+			var frameworkRequest = new HttpRequestMessage(new HttpMethod(request.Method), request.GetUrl());
 
 			return frameworkRequest;
 		}
 
-        private static void SetProxy(HttpWebRequest frameworkRequest)
-        {
-            WebProxy proxy = new WebProxy();
-            Uri proxyUri = new Uri(SmartyProxy.Address);
-            proxy.Address = proxyUri;
-
-            if (SmartyProxy.Username != null && SmartyProxy.Password != null)
-                proxy.Credentials = new NetworkCredential(SmartyProxy.Username, SmartyProxy.Password);
-    
-            frameworkRequest.Proxy = proxy;
-		}
-
-		private static void CopyHeaders(Request request, HttpWebRequest frameworkRequest)
+		private static void CopyHeaders(Request request, HttpRequestMessage frameworkRequest)
 		{
-			foreach (var item in request.Headers)
-			{
+			foreach (var item in request.Headers) {
 				if (item.Key == "Referer")
-					frameworkRequest.Referer = item.Value;
+					frameworkRequest.Headers.Referrer = new Uri(item.Value);
 				else
 					frameworkRequest.Headers.Add(item.Key, item.Value);
 			}
 
-			frameworkRequest.UserAgent = UserAgent;
+			frameworkRequest.Headers.UserAgent.ParseAdd(UserAgent);
 		}
-		private static void TryWritePayload(Request request, HttpWebRequest frameworkRequest)
+
+		private static void TryWritePayload(Request request, HttpRequestMessage frameworkRequest)
 		{
 			if (request.Method == "POST" && request.Payload != null)
-				using (var sourceStream = new MemoryStream(request.Payload))
-					CopyStream(sourceStream, GetRequestStream(frameworkRequest));
+				frameworkRequest.Content = new ByteArrayContent(request.Payload);
 		}
-		private static void CopyStream(Stream source, Stream target)
-		{
-			try
-			{
-				source.CopyTo(target);
-			}
-			catch (IOException ex)
-			{
-				throw new SmartyException("Unable to write to request stream.", ex);
-			}
-		}
-		private static Stream GetRequestStream(WebRequest request)
-		{
-			try
-			{
-				return request.GetRequestStream();
-			}
-			catch (WebException ex)
-			{
-				throw new SmartyException("Failed to make request.", ex);
-			}
-		}
-		private static HttpWebResponse GetResponse(WebRequest request)
-		{
-			try
-			{
-				return (HttpWebResponse)request.GetResponse();
-			}
-			catch (WebException e)
-			{
-				if (e.Response == null)
-					throw;
 
-				return (HttpWebResponse)e.Response;
-			}
-		}
-		private static byte[] GetResponseBody(WebResponse response)
+		private HttpResponseMessage GetResponse(HttpRequestMessage request)
 		{
-			var length = response.ContentLength >= 0 ? (int)response.ContentLength : 0;
+			return httpClient.SendAsync(request).Result;
+		}
 
-			using (var targetStream = new MemoryStream(length))
-			using (var responseStream = response.GetResponseStream())
-			{
-				CopyStream(responseStream, targetStream);
-				return targetStream.ToArray();
-			}
+		private static byte[] GetResponseBody(HttpResponseMessage response)
+		{
+			return response.Content.ReadAsByteArrayAsync().Result;
 		}
 	}
 }

--- a/src/sdk/SDK.csproj
+++ b/src/sdk/SDK.csproj
@@ -104,12 +104,40 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Net" />
   </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
-    <Folder Include="USExtractApi\" />
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
 </Project>

--- a/src/sdk/app.config
+++ b/src/sdk/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/sdk/packages.config
+++ b/src/sdk/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
+</packages>

--- a/src/tests/Tests.csproj
+++ b/src/tests/Tests.csproj
@@ -78,9 +78,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="USExtractApi\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/src/tests/app.config
+++ b/src/tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Using this library in a .NET Core 2.0 program, I was receiving the following error:

    System.PlatformNotSupportedException: Operation is not supported on this platform.
       at System.Net.SystemWebProxy.GetProxy(Uri destination)

This PR swaps out WebRequest for HttpClient, as generally suggested by the .NET team, eliminating the error.

Note: I have not tested the proxy code path.