### PR TITLE
Content Type on Batch Zip Code Send

### DIFF
--- a/src/examples/Program.cs
+++ b/src/examples/Program.cs
@@ -4,16 +4,16 @@
 	{
 		private static void Main()
 		{
-			USStreetSingleAddressExample.Run();
-			USStreetLookupsWithMatchStrategyExamples.Run();
-			USStreetMultipleAddressesExample.Run();
+			//USStreetSingleAddressExample.Run();
+			//USStreetLookupsWithMatchStrategyExamples.Run();
+			//USStreetMultipleAddressesExample.Run();
 			USZipCodeSingleLookupExample.Run();
 			USZipCodeMultipleLookupsExample.Run();
-			InternationalStreetExample.Run();
-			InternationalAutocompleteExample.Run();
-			USExtractExample.Run();
-			USAutocompleteProExample.Run();
-			USReverseGeoExample.Run();
+			//InternationalStreetExample.Run();
+			//InternationalAutocompleteExample.Run();
+			//USExtractExample.Run();
+			//USAutocompleteProExample.Run();
+			//USReverseGeoExample.Run();
 		}
 	}
 }

--- a/src/examples_frmwrk/App.config
+++ b/src/examples_frmwrk/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/src/examples_frmwrk/Program.cs
+++ b/src/examples_frmwrk/Program.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace examples_frmwrk
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            USZipCodeMultipleLookupsExample.Run();
+
+            Console.ReadLine();
+        }
+    }
+}

--- a/src/examples_frmwrk/Properties/AssemblyInfo.cs
+++ b/src/examples_frmwrk/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("examples_frmwrk")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("LRS")]
+[assembly: AssemblyProduct("examples_frmwrk")]
+[assembly: AssemblyCopyright("Copyright © LRS 2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fa59d02e-0955-4e60-9dd0-a2f6bf3719d1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/examples_frmwrk/USZipCodeMultipleLookupsExample.cs
+++ b/src/examples_frmwrk/USZipCodeMultipleLookupsExample.cs
@@ -1,0 +1,99 @@
+﻿namespace examples_frmwrk
+{
+	using System;
+	using System.IO;
+	using SmartyStreets;
+	using SmartyStreets.USZipCodeApi;
+
+	internal static class USZipCodeMultipleLookupsExample
+	{
+		public static void Run()
+		{
+			// You don't have to store your keys in environment variables, but we recommend it.
+			var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
+			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
+			var client = new ClientBuilder(authId, authToken).BuildUsZipCodeApiClient();
+
+			var lookup1 = new Lookup
+			{
+				InputId = "dfc33cb6-829e-4fea-aa1b-b6d6580f0817", // Optional ID from your system
+				ZipCode = "12345"
+			};
+
+			var lookup2 = new Lookup
+			{
+				City = "Phoenix",
+				State = "Arizona"
+			};
+
+			var lookup3 = new Lookup("cupertino", "CA", "95014") // You can also set these with arguments
+			{
+				InputId = "01189998819991197253"
+			};
+
+			var batch = new Batch();
+
+			try
+			{
+				batch.Add(lookup1);
+				batch.Add(lookup2);
+				batch.Add(lookup3);
+
+				client.Send(batch);
+			}
+			catch (BatchFullException)
+			{
+				Console.WriteLine("Error. The batch is already full.");
+			}
+			catch (SmartyException ex)
+			{
+				Console.WriteLine(ex.Message);
+				Console.WriteLine(ex.StackTrace);
+			}
+			catch (IOException ex)
+			{
+				Console.WriteLine(ex.StackTrace);
+			}
+
+			for (var i = 0; i < batch.Count; i++)
+			{
+				var result = batch[i].Result;
+				Console.WriteLine("Lookup " + i + ":\n");
+
+				if (result.Status != null)
+				{
+					Console.WriteLine("Status: " + result.Status);
+					Console.WriteLine("Reason: " + result.Reason);
+					continue;
+				}
+
+				Console.WriteLine("Input ID: " + result.InputId);
+
+				var cityStates = result.CityStates;
+				Console.WriteLine(cityStates.Length + " City and State match" + (cityStates.Length == 1 ? ":" : "es:"));
+
+				foreach (var cityState in cityStates)
+				{
+					Console.WriteLine("City: " + cityState.City);
+					Console.WriteLine("State: " + cityState.State);
+					Console.WriteLine("Mailable City: " + cityState.MailableCity);
+					Console.WriteLine();
+				}
+
+				var zipCodes = result.ZipCodes;
+				Console.WriteLine(zipCodes.Length + " ZIP Code match" + (cityStates.Length == 1 ? ":" : "es:"));
+
+				foreach (var zipCode in zipCodes)
+				{
+					Console.WriteLine("ZIP Code: " + zipCode.ZipCode);
+					Console.WriteLine("County: " + zipCode.CountyName);
+					Console.WriteLine("Latitude: " + zipCode.Latitude);
+					Console.WriteLine("Longitude: " + zipCode.Longitude);
+					Console.WriteLine();
+				}
+
+				Console.WriteLine("***********************************");
+			}
+		}
+	}
+}

--- a/src/examples_frmwrk/examples_frmwrk.csproj
+++ b/src/examples_frmwrk/examples_frmwrk.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FA59D02E-0955-4E60-9DD0-A2F6BF3719D1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>examples_frmwrk</RootNamespace>
+    <AssemblyName>examples_frmwrk</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="USZipCodeMultipleLookupsExample.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\sdk\sdk.csproj">
+      <Project>{078ec965-eb61-4757-b4ea-cf0387e7c050}</Project>
+      <Name>sdk</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/sdk/USZipCodeApi/Client.cs
+++ b/src/sdk/USZipCodeApi/Client.cs
@@ -40,7 +40,13 @@
 				PopulateQueryString(batch[0], request);
 			else
 			{
-				request.Headers.Add("Content-Type", "application/json");
+				// Per the discussion on this Stack Overflow thread, the suggested
+				// fix for this issue is to set the ContentType property on the
+				// Request object
+				//
+				// https://stackoverflow.com/questions/45076369/the-content-type-header-must-be-modified-using-the-appropriate-property-or-met
+				//
+				request.ContentType = "application/json";
 				request.Payload = batch.Serialize(this.serializer);
 			}
 

--- a/src/smartystreets-dotnet-sdk.sln
+++ b/src/smartystreets-dotnet-sdk.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2037
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sdk", "sdk\sdk.csproj", "{078EC965-EB61-4757-B4EA-CF0387E7C050}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "integration", "integration\integration.csproj", "{366C228F-8D22-4712-B5B8-A26B4F61AFBF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "examples", "examples\examples.csproj", "{F92D4539-4EB1-4399-BB8C-CFE6EDEB06D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "examples_frmwrk", "examples_frmwrk\examples_frmwrk.csproj", "{FA59D02E-0955-4E60-9DD0-A2F6BF3719D1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{F92D4539-4EB1-4399-BB8C-CFE6EDEB06D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F92D4539-4EB1-4399-BB8C-CFE6EDEB06D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F92D4539-4EB1-4399-BB8C-CFE6EDEB06D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA59D02E-0955-4E60-9DD0-A2F6BF3719D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA59D02E-0955-4E60-9DD0-A2F6BF3719D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA59D02E-0955-4E60-9DD0-A2F6BF3719D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA59D02E-0955-4E60-9DD0-A2F6BF3719D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
An exception is generated when a .NET Framework project accesses the libraries and attempts to send a batch of zip codes for lookup.  The content type is set in the headers and not set on the Request object.

I added a project that will expose the exception for testing purposes.  It was committed separately so that it can be removed if not needed going forward.