### PR TITLE
Added Randomness to sleep time during 429 error handling

### DIFF
--- a/src/examples/examples.csproj
+++ b/src/examples/examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net40</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\sdk\sdk.csproj" />

--- a/src/integration/integration.csproj
+++ b/src/integration/integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net40</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\sdk\sdk.csproj" />

--- a/src/sdk/ClientBuilder.cs
+++ b/src/sdk/ClientBuilder.cs
@@ -195,7 +195,7 @@ public InternationalAutocompleteApi.Client BuildInternationalAutocompleteApiClie
             sender = new URLPrefixSender(this.urlPrefix, sender);
 
             if (this.maxRetries > 0)
-                sender = new RetrySender(this.maxRetries, sender, this.Sleep);
+                sender = new RetrySender(this.maxRetries, sender, this.Sleep, new RandomGenerator());
             
             sender = new LicenseSender(this.licenses, sender);
 

--- a/src/sdk/Exceptions/TooManyRequestsException.cs
+++ b/src/sdk/Exceptions/TooManyRequestsException.cs
@@ -1,7 +1,10 @@
-﻿namespace SmartyStreets
+﻿using System;
+
+namespace SmartyStreets
 {
 	public class TooManyRequestsException : SmartyException
 	{
+		public Int64 RetryAfterInSeconds;
 		public TooManyRequestsException()
 		{
 		}
@@ -9,6 +12,12 @@
 		public TooManyRequestsException(string message)
 			: base(message)
 		{
+		}
+
+		public TooManyRequestsException(string message, Int64 retry)
+			: base(message)
+		{
+			RetryAfterInSeconds = retry;
 		}
 	}
 }

--- a/src/sdk/IRandomGenerator.cs
+++ b/src/sdk/IRandomGenerator.cs
@@ -1,0 +1,12 @@
+namespace SmartyStreets
+{
+    public interface IRandomGenerator
+    {
+        /// <summary>
+        /// Returns a random integer that is less than the value passed in.
+        /// </summary>
+        /// <param name="maxValue">The exclusive upper bound of the random number returned</param>
+        /// <returns>An integer that is greater than or equal to zero and less than maxValue.</returns>
+        int Next(int maxValue);
+    }
+}

--- a/src/sdk/LicenseSender.cs
+++ b/src/sdk/LicenseSender.cs
@@ -17,7 +17,7 @@ namespace SmartyStreets
 
         public Response Send(Request request)
         {
-            request.SetParameter("license", String.Join(",", this.licenses));
+            request.SetParameter("license", String.Join(",", this.licenses.ToArray()));
             return this.inner.Send(request);
         }
     }

--- a/src/sdk/NativeSender.cs
+++ b/src/sdk/NativeSender.cs
@@ -73,7 +73,17 @@
 		{
 			try
 			{
+#if NET35
+			    byte[] buffer = new byte[16 * 1024]; // Fairly arbitrary size
+			    int bytesRead;
+
+			    while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+			    {
+			        target.Write(buffer, 0, bytesRead);
+			    }
+#else
 				source.CopyTo(target);
+#endif
 			}
 			catch (IOException ex)
 			{

--- a/src/sdk/NativeSender.cs
+++ b/src/sdk/NativeSender.cs
@@ -36,7 +36,17 @@
 			var statusCode = (int)frameworkResponse.StatusCode;
 			var payload = GetResponseBody(frameworkResponse);
 
-			return new Response(statusCode, payload);
+			var retVal = new Response(statusCode, payload);
+			if (statusCode == 429)
+			{
+				string retryValue = frameworkResponse.Headers.Get("Retry-After");
+				if ((retryValue != null) && (retryValue.Length != 0))
+				{
+					retVal.HeaderInfo.Add("Retry-After", retryValue);
+				}
+			}
+
+			return retVal;
 		}
 
 		private HttpWebRequest BuildRequest(Request request)

--- a/src/sdk/Proxy.cs
+++ b/src/sdk/Proxy.cs
@@ -25,9 +25,25 @@
 			};
 		}
 
+		private static bool IsNullOrWhiteSpace(string value)
+		{
+#if NET35
+			if (value == null) return true;
+			
+			foreach (char c in value)
+			{
+				if (!char.IsWhiteSpace(c)) return false;
+			}
+
+			return true;
+
+#else
+ 			return string.IsNullOrWhiteSpace(value);
+#endif
+		}
 		private static System.Net.ICredentials ParseCredentials(string username, string password)
 		{
-			if (string.IsNullOrWhiteSpace(username) && string.IsNullOrWhiteSpace(password))
+			if (IsNullOrWhiteSpace(username) && IsNullOrWhiteSpace(password))
 				return CredentialCache.DefaultCredentials;
 
 			return new NetworkCredential(username, password);

--- a/src/sdk/RandomGenerator.cs
+++ b/src/sdk/RandomGenerator.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace SmartyStreets
+{
+    // Wrap the system random number generator, Random, in an interface so
+    // that it can be replaced with a pseudo random generator in the unit tests
+    public class RandomGenerator : IRandomGenerator
+    {
+        private readonly Random generator = new Random();
+
+        /// <summary>
+        /// Returns a random integer that is less than the value passed in.
+        /// </summary>
+        /// <param name="maxValue">The exclusive upper bound of the random number returned</param>
+        /// <returns>An integer that is greater than or equal to zero and less than maxValue.</returns>
+        public int Next(int maxValue)
+        {
+            return generator.Next(maxValue);
+        }
+    }
+}

--- a/src/sdk/Response.cs
+++ b/src/sdk/Response.cs
@@ -1,14 +1,21 @@
-﻿namespace SmartyStreets
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net;
+
+namespace SmartyStreets
 {
 	public class Response
 	{
 		public int StatusCode { get; }
 		public byte[] Payload { get; }
+		
+		public Dictionary<string, string> HeaderInfo { get; }
 
 		public Response(int statusCode, byte[] payload)
 		{
 			this.StatusCode = statusCode;
 			this.Payload = payload;
+			HeaderInfo = new Dictionary<string, string>();
 		}
 	}
 }

--- a/src/sdk/RetrySender.cs
+++ b/src/sdk/RetrySender.cs
@@ -7,19 +7,41 @@
 		private readonly int maxRetries;
 		private readonly ISender inner;
 		private Action<int> sleep;
+		private readonly IRandomGenerator randomNumGenerator;
 
-		public RetrySender(int maxRetries, ISender inner, Action<int> sleep)
+		private const int BackOffRateLimit = 5;
+		private const int MaxBackOffDuration = 10;
+
+		public RetrySender(int maxRetries, ISender inner, Action<int> sleep, IRandomGenerator generator)
 		{
 			this.maxRetries = maxRetries;
 			this.inner = inner;
 			this.sleep = sleep;
+			this.randomNumGenerator = generator;
+		}
+
+		private bool BackOff(int attempt)
+		{
+			if (attempt == 0)
+			{
+				return true;
+			}
+			if (attempt > this.maxRetries)
+			{
+				return false;
+			}
+
+			var backOffCap = Math.Max(0, Math.Min(MaxBackOffDuration, attempt));
+			var backOff = this.randomNumGenerator.Next(backOffCap) * 1000;
+			this.sleep(backOff);
+			return true;
 		}
 
 		public Response Send(Request request)
 		{
-			for (var i = 0; i <= this.maxRetries; i++)
+			for (var attempts = 0; BackOff(attempts); attempts++)
 			{
-				var response = this.TrySend(request, i);
+				var response = this.TrySend(request, ref attempts);
 				if (response != null)
 					return response;
 			}
@@ -27,7 +49,7 @@
 			return null;
 		}
 
-		private Response TrySend(Request request, int attempt)
+		private Response TrySend(Request request, ref int attempts)
 		{
 			try
 			{
@@ -35,13 +57,17 @@
 			}
 			catch (TooManyRequestsException)
 			{
-				if (attempt >= this.maxRetries)
-					throw;
-				this.sleep(5000);
+				attempts = 1;
+				var sleepDurationInMilliseconds = randomNumGenerator.Next(BackOffRateLimit)*1000;
+				this.sleep(sleepDurationInMilliseconds);
 			}
-			catch (Exception) // TODO: catch HTTP 400, 413, 422 and just throw.
+			catch (Exception ex) when ((ex is BadRequestException) || (ex is RequestEntityTooLargeException) || (ex is UnprocessableEntityException))
+			{ // catch HTTP 400, 413, 422 and just throw.
+				throw;
+			}
+			catch (Exception)
 			{
-				if (attempt >= this.maxRetries)
+				if (attempts >= this.maxRetries)
 					throw;
 			}
 

--- a/src/sdk/RetrySender.cs
+++ b/src/sdk/RetrySender.cs
@@ -55,10 +55,12 @@
 			{
 				return this.inner.Send(request);
 			}
-			catch (TooManyRequestsException)
+			catch (TooManyRequestsException e)
 			{
-				attempts = 1;
-				var sleepDurationInMilliseconds = randomNumGenerator.Next(BackOffRateLimit)*1000;
+				attempts = 0;
+				int sleepDurationInMilliseconds = (int)e.RetryAfterInSeconds*1000;
+					if (sleepDurationInMilliseconds == 0)
+						sleepDurationInMilliseconds= randomNumGenerator.Next(BackOffRateLimit)*1000;
 				this.sleep(sleepDurationInMilliseconds);
 			}
 			catch (Exception ex) when ((ex is BadRequestException) || (ex is RequestEntityTooLargeException) || (ex is UnprocessableEntityException))

--- a/src/sdk/StatusCodeSender.cs
+++ b/src/sdk/StatusCodeSender.cs
@@ -1,4 +1,6 @@
-﻿namespace SmartyStreets
+﻿using System;
+
+namespace SmartyStreets
 {
 	public class StatusCodeSender : ISender
 	{
@@ -35,8 +37,14 @@
 				case 422:
 					throw new UnprocessableEntityException("GET request lacked required fields.");
 				case 429:
+					string retry;
+					Int64 retryVal = 0;
+					if (response.HeaderInfo.TryGetValue("Retry-After", out retry))
+					{
+						Int64.TryParse(retry, out retryVal);
+					}
 					throw new TooManyRequestsException(
-						"When using public \"website key\" authentication, we restrict the number of requests coming from a given source over too short of a time.");
+						"When using public \"website key\" authentication, we restrict the number of requests coming from a given source over too short of a time.", retryVal);
 				case 500:
 					throw new InternalServerErrorException("Internal Server Error.");
 				case 503:

--- a/src/sdk/sdk.csproj
+++ b/src/sdk/sdk.csproj
@@ -19,4 +19,7 @@
     <AssemblyVersion>$(CustomVersion)</AssemblyVersion>
     <FileVersion>$(CustomVersion)</FileVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.ServiceModel.Web" Condition="'$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40'" />
+  </ItemGroup>
 </Project>

--- a/src/tests/Mocks/FakeRandomNumberGenerator.cs
+++ b/src/tests/Mocks/FakeRandomNumberGenerator.cs
@@ -1,0 +1,17 @@
+namespace SmartyStreets
+{
+    public class FakeRandomNumberGenerator : IRandomGenerator
+    {
+        private int nextNumber=1;
+
+        public int Next(int maxValue)
+        {
+            return nextNumber;
+        }
+
+        public void SetNextRandomNumber(int nextNum)
+        {
+            nextNumber = nextNum;
+        }
+    }
+}

--- a/src/tests/Mocks/MockCrashingSender.cs
+++ b/src/tests/Mocks/MockCrashingSender.cs
@@ -9,6 +9,9 @@
 		public const string RetryThreeTimes = "Retry Three Times";
 		public const string RetryMaxTimes = "Retry Max Times";
 		public const string TooManyRequests = "Too Many Requests";
+		public const string BadRequest = "Bad Request";
+		public const string RequestEntityTooLarge = "Request Entity Too Large";
+		public const string UnprocessableEntity = "Unprocessable Entity";
 
 		public int SendCount { get; private set; }
 
@@ -24,6 +27,15 @@
 			if (request.GetUrl().Contains(TooManyRequests))
 				if (this.SendCount == 1)
 					throw new TooManyRequestsException("Too many requests. Sleeping...");
+			if (request.GetUrl().Contains(BadRequest))
+				if (this.SendCount == 1)
+					throw new BadRequestException("Bad Request. Sleeping...");
+			if (request.GetUrl().Contains(RequestEntityTooLarge))
+				if (this.SendCount == 1)
+					throw new RequestEntityTooLargeException("Request Entity Too Large. Sleeping...");
+			if (request.GetUrl().Contains(UnprocessableEntity))
+				if (this.SendCount == 1)
+					throw new UnprocessableEntityException("Unprocessable Entity. Sleeping...");
 			if (request.GetUrl().Contains(RetryThreeTimes))
 				if (this.SendCount <= 3)
 					throw new IOException("You need to retry");


### PR DESCRIPTION
These changes add some randomness to the wait when a rate limit error is returned.  This helps when multiple clients are hitting the APIs and running up against a rate limit.