### PR TITLE
Changed 429 error handling to pass server error through

### DIFF
--- a/src/sdk/Exceptions/BadGatewayException.cs
+++ b/src/sdk/Exceptions/BadGatewayException.cs
@@ -1,0 +1,14 @@
+namespace SmartyStreets
+{
+    public class BadGatewayException : SmartyException
+    {
+        public BadGatewayException()
+        {
+        }
+
+        public BadGatewayException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/sdk/Exceptions/RequestTimeoutException.cs
+++ b/src/sdk/Exceptions/RequestTimeoutException.cs
@@ -1,0 +1,14 @@
+namespace SmartyStreets
+{
+    public class RequestTimeoutException : SmartyException
+    {
+        public RequestTimeoutException()
+        {
+        }
+
+        public RequestTimeoutException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/sdk/RetrySender.cs
+++ b/src/sdk/RetrySender.cs
@@ -1,4 +1,6 @@
-﻿namespace SmartyStreets
+﻿using System.IO;
+
+namespace SmartyStreets
 {
 	using System;
 
@@ -63,16 +65,12 @@
 						sleepDurationInMilliseconds= randomNumGenerator.Next(BackOffRateLimit)*1000;
 				this.sleep(sleepDurationInMilliseconds);
 			}
-			catch (Exception ex) when ((ex is BadRequestException) || (ex is RequestEntityTooLargeException) || (ex is UnprocessableEntityException))
-			{ // catch HTTP 400, 413, 422 and just throw.
-				throw;
-			}
-			catch (Exception)
+			catch (Exception ex) when ((ex is InternalServerErrorException) || (ex is ServiceUnavailableException) || (ex is GatewayTimeoutException) || (ex is RequestTimeoutException) || (ex is BadGatewayException) || (ex is IOException))
 			{
 				if (attempts >= this.maxRetries)
 					throw;
 			}
-
+			// all other exceptions are just allowed to be caught by the caller
 			return null;
 		}
 	}

--- a/src/sdk/StatusCodeSender.cs
+++ b/src/sdk/StatusCodeSender.cs
@@ -29,6 +29,9 @@ namespace SmartyStreets
 				case 403:
 					throw new ForbiddenException(
 						"Because the international service is currently in a limited release phase, only approved accounts may access the service.");
+				case 408:
+					throw new RequestTimeoutException(
+						"Request timeout error.");
 				case 413:
 					throw new RequestEntityTooLargeException(
 						"Request Entity Too Large: The request body has exceeded the maximum size.");
@@ -51,6 +54,8 @@ namespace SmartyStreets
 					throw new TooManyRequestsException(errorMsg, retryVal);
 				case 500:
 					throw new InternalServerErrorException("Internal Server Error.");
+				case 502:
+					throw new BadGatewayException("Bad Gateway error.");
 				case 503:
 					throw new ServiceUnavailableException("Service Unavailable. Try again later.");
 				case 504:

--- a/src/tests/Mocks/MockCrashingSender.cs
+++ b/src/tests/Mocks/MockCrashingSender.cs
@@ -12,8 +12,15 @@
 		public const string BadRequest = "Bad Request";
 		public const string RequestEntityTooLarge = "Request Entity Too Large";
 		public const string UnprocessableEntity = "Unprocessable Entity";
+		public const string RequestTimeout = "Request Timeout";
+		public const string BadGateway = "Bad Gateway";
+		public const string InternalServer = "Internal Server error";
+		public const string ServiceUnavailable = "Service Unavailable";
+		public const string GatewayTimeout = "Gateway Timeout";
 
 		public int SendCount { get; private set; }
+		
+		public int FailCount { get; set; }
 
 		public MockCrashingSender()
 		{
@@ -36,6 +43,24 @@
 			if (request.GetUrl().Contains(UnprocessableEntity))
 				if (this.SendCount == 1)
 					throw new UnprocessableEntityException("Unprocessable Entity. Sleeping...");
+			
+			// These exceptions should be retried until max is hit 
+			if (request.GetUrl().Contains(BadGateway))
+				if (this.SendCount < this.FailCount)
+					throw new BadGatewayException("Bad Gateway. Retrying...");
+			if (request.GetUrl().Contains(RequestTimeout))
+				if (this.SendCount < this.FailCount)
+					throw new RequestTimeoutException("Request Timeout. Retrying...");
+			if (request.GetUrl().Contains(InternalServer))
+				if (this.SendCount < this.FailCount)
+					throw new InternalServerErrorException("Internal Server error. Retrying...");
+			if (request.GetUrl().Contains(ServiceUnavailable))
+				if (this.SendCount < this.FailCount)
+					throw new ServiceUnavailableException("Service Unavailable. Retrying...");
+			if (request.GetUrl().Contains(GatewayTimeout))
+				if (this.SendCount < this.FailCount)
+					throw new GatewayTimeoutException("Gateway Timeout. Retrying...");
+			
 			if (request.GetUrl().Contains(RetryThreeTimes))
 				if (this.SendCount <= 3)
 					throw new IOException("You need to retry");


### PR DESCRIPTION
Added code to the 429 error handling to grab the error message that was sent from the server if there is one and use it instead of the more generic one in the SDK