### PR TITLE
Resolve MaxResults Parameter Issue

### DIFF
--- a/src/sdk/InternationalAutcompleteApi/Lookup.cs
+++ b/src/sdk/InternationalAutcompleteApi/Lookup.cs
@@ -44,7 +44,7 @@
 
 		#endregion
 		
-		internal string MaxSuggestionsString => this.MaxResults.Equals(MAX_RESULTS_DEFAULT) ? null : this.MaxResults.ToString();
+		internal string MaxSuggestionsString => this.MaxResults.ToString();
 
 	}
 }


### PR DESCRIPTION
Resolved issue where setting the MaxResults member would not actually change the parameter for the International Address Autocomplete API