### PR TITLE
Removed deprecated ServicePoint TLS declaration from all examples

### DIFF
--- a/src/examples/InternationalAutocompleteExample.cs
+++ b/src/examples/InternationalAutocompleteExample.cs
@@ -10,13 +10,9 @@ namespace Examples
     {
         public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // We recommend storing your secret keys in environment variables.
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildInternationalAutocompleteApiClient();
 			

--- a/src/examples/InternationalStreetExample.cs
+++ b/src/examples/InternationalStreetExample.cs
@@ -10,13 +10,10 @@
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
 
             // We recommend storing your secret keys in environment variables.
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildInternationalStreetApiClient();
 			

--- a/src/examples/USAutocompleteProExample.cs
+++ b/src/examples/USAutocompleteProExample.cs
@@ -10,10 +10,6 @@
 	{
 		public static void Run()
 		{
-			
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             //var key = Environment.GetEnvironmentVariable("SMARTY_AUTH_WEB");
 			//var hostname = Environment.GetEnvironmentVariable("SMARTY_WEBSITE_DOMAIN");
 			//var credentials = new SharedCredentials(key, hostname);
@@ -22,7 +18,6 @@
             var id = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var token = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
 			var credentials = new StaticCredentials(id, token);
-            ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
             using var client = new ClientBuilder(credentials).BuildUsAutocompleteProApiClient();
 

--- a/src/examples/USEnrichmentGeoReferenceExample.cs
+++ b/src/examples/USEnrichmentGeoReferenceExample.cs
@@ -10,16 +10,12 @@ namespace Examples
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocol to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
 
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsEnrichmentApiClient();
 			

--- a/src/examples/USEnrichmentPropertyExample.cs
+++ b/src/examples/USEnrichmentPropertyExample.cs
@@ -9,16 +9,12 @@ namespace Examples
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
 
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsEnrichmentApiClient();
 			

--- a/src/examples/USEnrichmentRiskExample.cs
+++ b/src/examples/USEnrichmentRiskExample.cs
@@ -10,8 +10,6 @@ namespace Examples
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocol to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
 
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
@@ -19,7 +17,6 @@ namespace Examples
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsEnrichmentApiClient();
 			

--- a/src/examples/USEnrichmentSecondaryExample.cs
+++ b/src/examples/USEnrichmentSecondaryExample.cs
@@ -10,16 +10,12 @@ namespace Examples
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
 
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsEnrichmentApiClient();
 			

--- a/src/examples/USEnrichmentUniversalExample.cs
+++ b/src/examples/USEnrichmentUniversalExample.cs
@@ -10,16 +10,12 @@ namespace Examples
     {
         public static void Run()
         {
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
 
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
             var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-            ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
             using var client = new ClientBuilder(authId, authToken).BuildUsEnrichmentApiClient();
 

--- a/src/examples/USExtractExample.cs
+++ b/src/examples/USExtractExample.cs
@@ -10,13 +10,9 @@
 	{
 		public static void  Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // We recommend storing your secret keys in environment variables.
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsExtractApiClient();
 			var text = "Here is some text.\r\nMy address is 3785 Las Vegs Av." +

--- a/src/examples/USReverseGeoExample.cs
+++ b/src/examples/USReverseGeoExample.cs
@@ -10,16 +10,12 @@
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
 
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken)
 				//.WithCustomBaseUrl("us-street-reverse-geo.api.smarty.com")

--- a/src/examples/USStreetLookupsWithMatchStrategyExamples.cs
+++ b/src/examples/USStreetLookupsWithMatchStrategyExamples.cs
@@ -10,13 +10,9 @@
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // You don't have to store your keys in environment variables, but we recommend it.
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsStreetApiClient();
 			var batch = new Batch();

--- a/src/examples/USStreetMultipleAddressesExample.cs
+++ b/src/examples/USStreetMultipleAddressesExample.cs
@@ -10,13 +10,9 @@
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // You don't have to store your keys in environment variables, but we recommend it.
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsStreetApiClient();
 			var batch = new Batch();

--- a/src/examples/USStreetSingleAddressEndpointExample.cs
+++ b/src/examples/USStreetSingleAddressEndpointExample.cs
@@ -10,16 +10,12 @@
 	{
 		public static void Run()
 		{
-            // specifies the TLS protocoll to use - this is TLS 1.2
-            const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
             // var authId = "Your SmartyStreets Auth ID here";
             // var authToken = "Your SmartyStreets Auth Token here";
 
             // We recommend storing your keys in environment variables instead---it's safer!
             var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken)
 				// NOTE: this is how to point the SDK at an alternate installation

--- a/src/examples/USStreetSingleAddressExample.cs
+++ b/src/examples/USStreetSingleAddressExample.cs
@@ -10,17 +10,12 @@
 	{
 		public static void Run()
 		{
-			// specifies the TLS protocol to use - this is TLS 1.2
-			const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
 			// var authId = "Your SmartyStreets Auth ID here";
 			// var authToken = "Your SmartyStreets Auth Token here";
 
 			// We recommend storing your keys in environment variables instead---it's safer!
 			var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken)
 				//.WithCustomBaseUrl("us-street.api.smarty.com")

--- a/src/examples/USZipCodeMultipleLookupsExample.cs
+++ b/src/examples/USZipCodeMultipleLookupsExample.cs
@@ -10,13 +10,9 @@
 	{
 		public static void Run()
 		{
-			// specifies the TLS protocoll to use - this is TLS 1.2
-			const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
 			// You don't have to store your keys in environment variables, but we recommend it.
 			var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken)
 				.BuildUsZipCodeApiClient();

--- a/src/examples/USZipCodeSingleLookupExample.cs
+++ b/src/examples/USZipCodeSingleLookupExample.cs
@@ -10,13 +10,9 @@
 	{
 		public static void Run()
 		{
-			// specifies the TLS protocoll to use - this is TLS 1.2
-			const SecurityProtocolType tlsProtocol1_2 = (SecurityProtocolType)3072;
-
 			// You don't have to store your keys in environment variables, but we recommend it.
 			var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
 			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
-			ServicePointManager.SecurityProtocol = tlsProtocol1_2;
 
 			using var client = new ClientBuilder(authId, authToken).BuildUsZipCodeApiClient();
 


### PR DESCRIPTION
The manual specification of a TLS version for the .NET SDK was only necessary with the WebClient implementation, and is no longer necessary with the new HttpClient implementation as of version 4.0.0. Because of this. Running an example out of the box on version 4.0.0 or higher results in a warning that ServicePoint is deprecated. I propose we remove the manual TLS declaration entirely from the examples