### PR TITLE
Added three new fields to the Metadata struct: IANATimeZone (string), IANAUTCOffset (float32), and IANADST (bool). These three new fields are accessible via setting a new feature flag "iana-timezone" 

### DIFF
--- a/src/sdk/ClientBuilder.cs
+++ b/src/sdk/ClientBuilder.cs
@@ -182,6 +182,9 @@ namespace SmartyStreets
             return this.WithCustomCommaSeparatedQuery("features", "component-analysis");
         }
 
+        /// <summary>
+        ///     WithFeatureIanaTimeZone turns on the IANA timezone feature for the request.
+        /// </summary>
         public ClientBuilder WithFeatureIanaTimeZone()
         {
             return this.WithCustomCommaSeparatedQuery("features", "iana-timezone");

--- a/src/sdk/ClientBuilder.cs
+++ b/src/sdk/ClientBuilder.cs
@@ -182,6 +182,11 @@ namespace SmartyStreets
             return this.WithCustomCommaSeparatedQuery("features", "component-analysis");
         }
 
+        public ClientBuilder WithFeatureIANATimeZone()
+        {
+            return this.WithCustomCommaSeparatedQuery("features", "iana-timezone");
+        }
+
         public InternationalStreetApi.Client BuildInternationalStreetApiClient()
         {
             this.EnsureURLPrefixNotNull(InternationalStreetApiUrl);

--- a/src/sdk/ClientBuilder.cs
+++ b/src/sdk/ClientBuilder.cs
@@ -182,7 +182,7 @@ namespace SmartyStreets
             return this.WithCustomCommaSeparatedQuery("features", "component-analysis");
         }
 
-        public ClientBuilder WithFeatureIANATimeZone()
+        public ClientBuilder WithFeatureIanaTimeZone()
         {
             return this.WithCustomCommaSeparatedQuery("features", "iana-timezone");
         }

--- a/src/sdk/USStreetApi/Metadata.cs
+++ b/src/sdk/USStreetApi/Metadata.cs
@@ -56,13 +56,13 @@
 		public bool ObeysDst { get; set; }
 
 		[DataMember(Name = "iana_time_zone")]
-		public string IANATimeZone { get; set; }
+		public string IanaTimeZone { get; set; }
 
 		[DataMember(Name = "iana_utc_offset")]
-		public float IANAUTCOffset { get; set; }
+		public double IanaUtcOffset { get; set; }
 
 		[DataMember(Name = "iana_dst")]
-		public bool IANADST { get; set; }
+		public bool IanaObeysDst { get; set; }
 
 		[DataMember(Name = "ews_match")]
 		public bool IsEwsMatch { get; set; }

--- a/src/sdk/USStreetApi/Metadata.cs
+++ b/src/sdk/USStreetApi/Metadata.cs
@@ -54,7 +54,16 @@
 
 		[DataMember(Name = "dst")]
 		public bool ObeysDst { get; set; }
-		
+
+		[DataMember(Name = "iana_time_zone")]
+		public string IANATimeZone { get; set; }
+
+		[DataMember(Name = "iana_utc_offset")]
+		public float IANAUTCOffset { get; set; }
+
+		[DataMember(Name = "iana_dst")]
+		public bool IANADST { get; set; }
+
 		[DataMember(Name = "ews_match")]
 		public bool IsEwsMatch { get; set; }
 

--- a/src/tests/ClientBuilderTests.cs
+++ b/src/tests/ClientBuilderTests.cs
@@ -15,19 +15,19 @@ namespace SmartyStreets
         }
 
         [Test]
-        public void TestWithFeatureIANATimeZone()
+        public void TestWithFeatureIanaTimeZone()
         {
-            var builder = new ClientBuilder().WithFeatureIANATimeZone();
+            var builder = new ClientBuilder().WithFeatureIanaTimeZone();
 
             Assert.AreEqual("iana-timezone", GetCustomQueries(builder)["features"]);
         }
 
         [Test]
-        public void TestWithFeatureIANATimeZoneAndComponentAnalysis_ShouldAppend()
+        public void TestWithFeatureIanaTimeZoneAndComponentAnalysis_ShouldAppend()
         {
             var builder = new ClientBuilder()
                 .WithFeatureComponentAnalysis()
-                .WithFeatureIANATimeZone();
+                .WithFeatureIanaTimeZone();
 
             Assert.AreEqual("component-analysis,iana-timezone", GetCustomQueries(builder)["features"]);
         }

--- a/src/tests/ClientBuilderTests.cs
+++ b/src/tests/ClientBuilderTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace SmartyStreets
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ClientBuilderTests
+    {
+        private static Dictionary<string, string> GetCustomQueries(ClientBuilder builder)
+        {
+            var field = typeof(ClientBuilder).GetField("customQueries", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (Dictionary<string, string>)field.GetValue(builder);
+        }
+
+        [Test]
+        public void TestWithFeatureIANATimeZone()
+        {
+            var builder = new ClientBuilder().WithFeatureIANATimeZone();
+
+            Assert.AreEqual("iana-timezone", GetCustomQueries(builder)["features"]);
+        }
+
+        [Test]
+        public void TestWithFeatureIANATimeZoneAndComponentAnalysis_ShouldAppend()
+        {
+            var builder = new ClientBuilder()
+                .WithFeatureComponentAnalysis()
+                .WithFeatureIANATimeZone();
+
+            Assert.AreEqual("component-analysis,iana-timezone", GetCustomQueries(builder)["features"]);
+        }
+    }
+}

--- a/src/tests/tests.csproj
+++ b/src/tests/tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>SmartyStreets</RootNamespace>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\sdk\sdk.csproj" />


### PR DESCRIPTION
Added three new fields to the Metadata struct: IANATimeZone (string), IANAUTCOffset (float32), and IANADST (bool). These three new fields are accessible via setting a new feature flag "iana-timezone" 