### PR TITLE
reverse_geo 422 error handling fix and testing

### DIFF
--- a/src/sdk/StatusCodeSender.cs
+++ b/src/sdk/StatusCodeSender.cs
@@ -33,24 +33,32 @@ namespace SmartyStreets
 						ExtractResponseEtag(response));
 				case 401:
 					throw new BadCredentialsException(
-						"Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.");
+						ExtractErrorMsgFromResponse(response,
+							"Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."));
 				case 402:
 					throw new PaymentRequiredException(
-						"Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.");
+						ExtractErrorMsgFromResponse(response,
+							"Payment Required: There is no active subscription for the account associated with the credentials submitted with the request."));
 				case 403:
 					throw new ForbiddenException(
-						"Because the international service is currently in a limited release phase, only approved accounts may access the service.");
+						ExtractErrorMsgFromResponse(response,
+							"Because the international service is currently in a limited release phase, only approved accounts may access the service."));
 				case 408:
 					throw new RequestTimeoutException(
-						"Request timeout error.");
+						ExtractErrorMsgFromResponse(response,
+							"Request timeout error."));
 				case 413:
 					throw new RequestEntityTooLargeException(
-						"Request Entity Too Large: The request body has exceeded the maximum size.");
+						ExtractErrorMsgFromResponse(response,
+							"Request Entity Too Large: The request body has exceeded the maximum size."));
 				case 400:
 					throw new BadRequestException(
-						"Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.");
+						ExtractErrorMsgFromResponse(response,
+							"Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON."));
 				case 422:
-					throw new UnprocessableEntityException("GET request lacked required fields.");
+					throw new UnprocessableEntityException(
+						ExtractErrorMsgFromResponse(response,
+							"GET request lacked required fields."));
 				case 429:
 					string retry;
 					Int64 retryVal = 0;

--- a/src/tests/StatusCodeSenderTests.cs
+++ b/src/tests/StatusCodeSenderTests.cs
@@ -1,5 +1,6 @@
 namespace SmartyStreets
 {
+    using System.Text;
     using System.Threading.Tasks;
     using NUnit.Framework;
 
@@ -12,11 +13,43 @@ namespace SmartyStreets
 			Assert.DoesNotThrowAsync(async () => await Send(200));
 			Assert.ThrowsAsync<BadCredentialsException>(async () => await Send(401));
 			Assert.ThrowsAsync<PaymentRequiredException>(async () => await Send(402));
+			Assert.ThrowsAsync<ForbiddenException>(async () => await Send(403));
+			Assert.ThrowsAsync<RequestTimeoutException>(async () => await Send(408));
 			Assert.ThrowsAsync<RequestEntityTooLargeException>(async () => await Send(413));
 			Assert.ThrowsAsync<BadRequestException>(async () => await Send(400));
+			Assert.ThrowsAsync<UnprocessableEntityException>(async () => await Send(422));
 			Assert.ThrowsAsync<TooManyRequestsException>(async () => await Send(429));
 			Assert.ThrowsAsync<InternalServerErrorException>(async () => await Send(500));
 			Assert.ThrowsAsync<ServiceUnavailableException>(async () => await Send(503));
+		}
+
+		[Test]
+		public void TestSurfacesApiErrorMessageOn422()
+		{
+			var payload = Encoding.UTF8.GetBytes("{\"errors\":[{\"message\":\"Specific error from the API.\"}]}");
+			var sender = new StatusCodeSender(new MockSender(new Response(422, payload)));
+
+			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
+			Assert.AreEqual("Specific error from the API.", ex.Message);
+		}
+
+		[Test]
+		public void TestFallsBackToCannedMessageOn422WhenBodyUnusable()
+		{
+			var payload = Encoding.UTF8.GetBytes("not valid json with no message field");
+			var sender = new StatusCodeSender(new MockSender(new Response(422, payload)));
+
+			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
+			Assert.AreEqual("GET request lacked required fields.", ex.Message);
+		}
+
+		[Test]
+		public void TestFallsBackToCannedMessageOn422WhenBodyEmpty()
+		{
+			var sender = new StatusCodeSender(new MockSender(new Response(422, null)));
+
+			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
+			Assert.AreEqual("GET request lacked required fields.", ex.Message);
 		}
 
 		[Test]


### PR DESCRIPTION
Made 422 and other 400 errors (not including 429) return the error message from the api as part of their error. 