### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/src/examples/USEnrichmentEtagExample.cs
+++ b/src/examples/USEnrichmentEtagExample.cs
@@ -48,11 +48,10 @@ namespace Examples
             try
             {
                 client.SendBusinessLookup(second);
-                Console.WriteLine($"  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Results={second.GetResults()?.Length ?? 0}, Etag={Display(second.GetResponseEtag())}");
-            }
-            catch (NotModifiedException ex)
-            {
-                Console.WriteLine($"  Call 2 (matching Etag): 304 NotModifiedException — caller treats this as cache-valid. Refreshed Etag={Display(ex.ResponseEtag)}");
+                if (second.GetResults() == null)
+                    Console.WriteLine($"  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag={Display(second.GetResponseEtag())}");
+                else
+                    Console.WriteLine($"  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Results={second.GetResults()?.Length ?? 0}, Etag={Display(second.GetResponseEtag())}");
             }
             catch (Exception ex)
             {
@@ -65,11 +64,10 @@ namespace Examples
             try
             {
                 client.SendBusinessLookup(third);
-                Console.WriteLine($"  Call 3 (mutated Etag): 200 as expected. Results={third.GetResults()?.Length ?? 0}, Etag={Display(third.GetResponseEtag())}");
-            }
-            catch (NotModifiedException)
-            {
-                Console.WriteLine("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+                if (third.GetResults() == null)
+                    Console.WriteLine("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+                else
+                    Console.WriteLine($"  Call 3 (mutated Etag): 200 as expected. Results={third.GetResults()?.Length ?? 0}, Etag={Display(third.GetResponseEtag())}");
             }
             catch (Exception ex)
             {
@@ -103,11 +101,10 @@ namespace Examples
             try
             {
                 client.SendBusinessDetailLookup(second);
-                Console.WriteLine($"  Call 2 (matching Etag): 200 — server did NOT honor the conditional. businessId={second.GetResult()?.BusinessId ?? "<null>"}, Etag={Display(second.GetResponseEtag())}");
-            }
-            catch (NotModifiedException ex)
-            {
-                Console.WriteLine($"  Call 2 (matching Etag): 304 NotModifiedException — caller treats this as cache-valid. Refreshed Etag={Display(ex.ResponseEtag)}");
+                if (second.GetResult() == null)
+                    Console.WriteLine($"  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag={Display(second.GetResponseEtag())}");
+                else
+                    Console.WriteLine($"  Call 2 (matching Etag): 200 — server did NOT honor the conditional. businessId={second.GetResult()?.BusinessId ?? "<null>"}, Etag={Display(second.GetResponseEtag())}");
             }
             catch (Exception ex)
             {
@@ -120,11 +117,10 @@ namespace Examples
             try
             {
                 client.SendBusinessDetailLookup(third);
-                Console.WriteLine($"  Call 3 (mutated Etag): 200 as expected. businessId={third.GetResult()?.BusinessId ?? "<null>"}, Etag={Display(third.GetResponseEtag())}");
-            }
-            catch (NotModifiedException)
-            {
-                Console.WriteLine("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+                if (third.GetResult() == null)
+                    Console.WriteLine("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+                else
+                    Console.WriteLine($"  Call 3 (mutated Etag): 200 as expected. businessId={third.GetResult()?.BusinessId ?? "<null>"}, Etag={Display(third.GetResponseEtag())}");
             }
             catch (Exception ex)
             {

--- a/src/examples/USEnrichmentGeoReferenceExample.cs
+++ b/src/examples/USEnrichmentGeoReferenceExample.cs
@@ -47,9 +47,6 @@ namespace Examples
                 // Send a lookup using the line below
                 results = client.SendGeoReferenceLookup(lookup); // more flexible call to set other lookup options
             }
-            catch (NotModifiedException ex) {
-                Console.WriteLine(ex.Message); // The Etag value provided represents the latest version of the requested record
-            }
             catch (Exception ex) {
                 Console.WriteLine(ex.Message + ex.StackTrace);
             }

--- a/src/examples/USEnrichmentPropertyExample.cs
+++ b/src/examples/USEnrichmentPropertyExample.cs
@@ -51,9 +51,6 @@ namespace Examples
                 // Send a lookup using the line below
                 results = client.SendPropertyPrincipalLookup(lookup); // more flexible call to set other lookup options
             }
-            catch (NotModifiedException ex) {
-                Console.WriteLine(ex.Message); // The Etag value provided represents the latest version of the requested record
-            }
             catch (Exception ex) {
                 Console.WriteLine(ex.Message + ex.StackTrace);
             }

--- a/src/examples/USEnrichmentSecondaryExample.cs
+++ b/src/examples/USEnrichmentSecondaryExample.cs
@@ -48,9 +48,6 @@ namespace Examples
                 // Send a lookup using the line below
                 results = client.SendSecondaryLookup(lookup);
             }
-            catch (NotModifiedException ex) {
-                Console.WriteLine(ex.Message); // The Etag value provided represents the latest version of the requested record
-            }
             catch (Exception ex) {
                 Console.WriteLine(ex.Message + ex.StackTrace);
             }
@@ -105,9 +102,6 @@ namespace Examples
 
                 // Send a lookup using the line below
                 countResults = client.SendSecondaryCountLookup(countLookup);
-            }
-            catch (NotModifiedException ex) {
-                Console.WriteLine(ex.Message); // The Etag value provided represents the latest version of the requested record
             }
             catch (Exception ex) {
                 Console.WriteLine(ex.Message + ex.StackTrace);

--- a/src/examples/USEnrichmentUniversalExample.cs
+++ b/src/examples/USEnrichmentUniversalExample.cs
@@ -55,10 +55,6 @@ namespace Examples
                 // Send a lookup using the line below
                 results = client.SendUniversalLookup(freeformLookup);
             }
-            catch (NotModifiedException ex)
-            {
-                Console.WriteLine(ex.Message); // The Etag value provided represents the latest version of the requested record
-            }
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message + ex.StackTrace);

--- a/src/sdk/NativeSerializer.cs
+++ b/src/sdk/NativeSerializer.cs
@@ -20,7 +20,7 @@
 
 		public T Deserialize<T>(Stream source) where T : class
 		{
-			if (source == null)
+			if (source == null || source.Length == 0)
 				return null;
 
 			var serializer = new DataContractJsonSerializer(typeof(T));

--- a/src/sdk/StatusCodeSender.cs
+++ b/src/sdk/StatusCodeSender.cs
@@ -1,5 +1,9 @@
 ﻿using System;
-using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
 
 namespace SmartyStreets
@@ -103,22 +107,25 @@ namespace SmartyStreets
 			return null;
 		}
 
-		private string ExtractErrorMsgFromResponse(Response response, string defaultErrorMessage)
+		private static string ExtractErrorMsgFromResponse(Response response, string defaultErrorMessage)
 		{
+			string payloadString = null;
 			try
 			{
 				// do this in a try-catch to ensure any exception is caught.  Don't need to handle any error since we have a generic error message
-				var payloadString = System.Text.Encoding.UTF8.GetString(response.Payload);
-				var exp = new Regex("\"message\" *: *\"[^\"]*\""); // look for "message":"<some error text>"
-				var innerExp = new Regex("\"[^\"]*\""); // look for text that is included inside of double quotes
-				var matches = exp.Matches(payloadString);
-				foreach (Match match in matches)
+				payloadString = System.Text.Encoding.UTF8.GetString(response.Payload);
+				using (var stream = new MemoryStream(response.Payload))
 				{
-					string errorPair = match.Value.Substring(9); // skip over "message"
-					string error = innerExp.Match(errorPair).Value;
-					if (error.Length > 2) // make sure string isn't just a quoted empty string 
+					var payload = (ErrorPayload)new DataContractJsonSerializer(typeof(ErrorPayload)).ReadObject(stream);
+					if (payload?.Errors != null)
 					{
-						return error.Substring(1, error.Length - 2);
+						var message = string.Join(" ", payload.Errors
+							.Where(error => !string.IsNullOrWhiteSpace(error?.Message))
+							.Select(error => error.Message.Trim()));
+						if (message.Length > 0)
+						{
+							return message;
+						}
 					}
 				}
 			}
@@ -126,7 +133,21 @@ namespace SmartyStreets
 			{
 			}
 
-			return defaultErrorMessage;
+			return (defaultErrorMessage + " Body: " + (payloadString?.Trim() ?? "")).TrimEnd();
+		}
+
+		[DataContract]
+		private class ErrorPayload
+		{
+			[DataMember(Name = "errors", IsRequired = false)]
+			public List<ApiError> Errors { get; set; }
+		}
+
+		[DataContract]
+		private class ApiError
+		{
+			[DataMember(Name = "message", IsRequired = false)]
+			public string Message { get; set; }
 		}
 
 		public void Dispose()

--- a/src/sdk/StatusCodeSender.cs
+++ b/src/sdk/StatusCodeSender.cs
@@ -30,11 +30,8 @@ namespace SmartyStreets
 			switch (response.StatusCode)
 			{
 				case 200:
-					return response;
 				case 304:
-					throw new NotModifiedException(
-						"Not Modified: The requested record has not been modified since the previous request with the Etag value.",
-						ExtractResponseEtag(response));
+					return response;
 				case 401:
 					throw new BadCredentialsException(
 						ExtractErrorMsgFromResponse(response,
@@ -93,18 +90,6 @@ namespace SmartyStreets
 						ExtractErrorMsgFromResponse(response,
 							"The server returned an unexpected HTTP status code: " + response.StatusCode));
 			}
-		}
-
-		private static string ExtractResponseEtag(Response response)
-		{
-			if (response.HeaderInfo == null)
-				return null;
-			foreach (var entry in response.HeaderInfo)
-			{
-				if (string.Equals(entry.Key, "Etag", StringComparison.OrdinalIgnoreCase))
-					return entry.Value;
-			}
-			return null;
 		}
 
 		private static string ExtractErrorMsgFromResponse(Response response, string defaultErrorMessage)

--- a/src/sdk/StatusCodeSender.cs
+++ b/src/sdk/StatusCodeSender.cs
@@ -42,7 +42,7 @@ namespace SmartyStreets
 				case 403:
 					throw new ForbiddenException(
 						ExtractErrorMsgFromResponse(response,
-							"Because the international service is currently in a limited release phase, only approved accounts may access the service."));
+							"Forbidden: The request contained valid data and was understood by the server, but the server is refusing action."));
 				case 408:
 					throw new RequestTimeoutException(
 						ExtractErrorMsgFromResponse(response,
@@ -54,7 +54,7 @@ namespace SmartyStreets
 				case 400:
 					throw new BadRequestException(
 						ExtractErrorMsgFromResponse(response,
-							"Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON."));
+							"Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON."));
 				case 422:
 					throw new UnprocessableEntityException(
 						ExtractErrorMsgFromResponse(response,
@@ -68,20 +68,26 @@ namespace SmartyStreets
 						Int64.TryParse(retry, out retryVal);
 					}
 
-					var errorMsg = ExtractErrorMsgFromResponse(response, "When using public \"website key\" authentication, we restrict the number of requests coming from a given source over too short of a time.");
+					var errorMsg = ExtractErrorMsgFromResponse(response, "Too Many Requests: The rate limit for your account has been exceeded.");
 
 					throw new TooManyRequestsException(errorMsg, retryVal);
 				case 500:
-					throw new InternalServerErrorException("Internal Server Error.");
+					throw new InternalServerErrorException(
+						ExtractErrorMsgFromResponse(response, "Internal Server Error."));
 				case 502:
-					throw new BadGatewayException("Bad Gateway error.");
+					throw new BadGatewayException(
+						ExtractErrorMsgFromResponse(response, "Bad Gateway error."));
 				case 503:
-					throw new ServiceUnavailableException("Service Unavailable. Try again later.");
+					throw new ServiceUnavailableException(
+						ExtractErrorMsgFromResponse(response, "Service Unavailable. Try again later."));
 				case 504:
 					throw new GatewayTimeoutException(
-						"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.");
+						ExtractErrorMsgFromResponse(response,
+							"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed."));
 				default:
-					return null;
+					throw new SmartyException(
+						ExtractErrorMsgFromResponse(response,
+							"The server returned an unexpected HTTP status code: " + response.StatusCode));
 			}
 		}
 

--- a/src/sdk/USEnrichmentApi/Client.cs
+++ b/src/sdk/USEnrichmentApi/Client.cs
@@ -197,6 +197,10 @@ namespace SmartyStreets.USEnrichmentApi
 						lookup.SetResponseEtag(entry.Value);
 				}
 			}
+			if (response.StatusCode == 304)
+			{
+				return;
+			}
 			if (response.Payload != null)
 			{
 				using (var payloadStream = new MemoryStream(response.Payload))

--- a/src/tests/NativeSerializerTests.cs
+++ b/src/tests/NativeSerializerTests.cs
@@ -41,6 +41,14 @@
 		}
 
 		[Test]
+		public void TestDeserializationOfEmptyStream()
+		{
+			var result = this.serializer.Deserialize<NativeSerializerTestObject>(new MemoryStream());
+
+			Assert.IsNull(result);
+		}
+
+		[Test]
 		public void TestDeserializationOfKnownType()
 		{
 			var expected = new NativeSerializerTestObject

--- a/src/tests/StatusCodeSenderTests.cs
+++ b/src/tests/StatusCodeSenderTests.cs
@@ -124,35 +124,16 @@ namespace SmartyStreets
 		}
 
 		[Test]
-		public void TestNotModifiedExceptionCarriesResponseEtag()
+		public void TestNotModifiedIsNotAnError()
 		{
 			var response = new Response(304, null);
 			response.HeaderInfo["Etag"] = "server-refreshed-etag";
 			var sender = new StatusCodeSender(new MockSender(response));
 
-			var ex = Assert.Throws<NotModifiedException>(() => sender.Send(new Request()));
-			Assert.AreEqual("server-refreshed-etag", ex.ResponseEtag);
-		}
+			var result = sender.Send(new Request());
 
-		[Test]
-		public void TestNotModifiedExceptionResponseEtagIsCaseInsensitive()
-		{
-			var response = new Response(304, null);
-			response.HeaderInfo["ETag"] = "case-insensitive-etag";
-			var sender = new StatusCodeSender(new MockSender(response));
-
-			var ex = Assert.Throws<NotModifiedException>(() => sender.Send(new Request()));
-			Assert.AreEqual("case-insensitive-etag", ex.ResponseEtag);
-		}
-
-		[Test]
-		public void TestNotModifiedExceptionResponseEtagNullWhenHeaderAbsent()
-		{
-			var response = new Response(304, null);
-			var sender = new StatusCodeSender(new MockSender(response));
-
-			var ex = Assert.Throws<NotModifiedException>(() => sender.Send(new Request()));
-			Assert.IsNull(ex.ResponseEtag);
+			Assert.AreEqual(304, result.StatusCode);
+			Assert.AreEqual("server-refreshed-etag", result.HeaderInfo["Etag"]);
 		}
 
 		private static async Task Send(int statusCode)

--- a/src/tests/StatusCodeSenderTests.cs
+++ b/src/tests/StatusCodeSenderTests.cs
@@ -75,13 +75,43 @@ namespace SmartyStreets
 		}
 
 		[Test]
-		public void TestFallsBackToCannedMessageOn422WhenBodyUnusable()
+		public void TestJoinsMultipleApiErrorMessages()
+		{
+			var payload = Encoding.UTF8.GetBytes("{\"errors\":[{\"message\":\"First problem.\"},{\"message\":\"Second problem.\"}]}");
+			var sender = new StatusCodeSender(new MockSender(new Response(422, payload)));
+
+			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
+			Assert.AreEqual("First problem. Second problem.", ex.Message);
+		}
+
+		[Test]
+		public void TestFallbackAppendsBodyWhenErrorsCarryNoMessages()
+		{
+			var payload = Encoding.UTF8.GetBytes("{\"errors\":[]}");
+			var sender = new StatusCodeSender(new MockSender(new Response(422, payload)));
+
+			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
+			Assert.AreEqual("GET request lacked required fields. Body: {\"errors\":[]}", ex.Message);
+		}
+
+		[Test]
+		public void TestFallsBackAndAppendsBodyOn422WhenBodyUnusable()
 		{
 			var payload = Encoding.UTF8.GetBytes("not valid json with no message field");
 			var sender = new StatusCodeSender(new MockSender(new Response(422, payload)));
 
 			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
-			Assert.AreEqual("GET request lacked required fields.", ex.Message);
+			Assert.AreEqual("GET request lacked required fields. Body: not valid json with no message field", ex.Message);
+		}
+
+		[Test]
+		public void TestWhitespaceOnlyBodyYieldsEmptyBodyLabel()
+		{
+			var payload = Encoding.UTF8.GetBytes("   \n  ");
+			var sender = new StatusCodeSender(new MockSender(new Response(422, payload)));
+
+			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
+			Assert.AreEqual("GET request lacked required fields. Body:", ex.Message);
 		}
 
 		[Test]
@@ -90,7 +120,7 @@ namespace SmartyStreets
 			var sender = new StatusCodeSender(new MockSender(new Response(422, null)));
 
 			var ex = Assert.Throws<UnprocessableEntityException>(() => sender.Send(new Request()));
-			Assert.AreEqual("GET request lacked required fields.", ex.Message);
+			Assert.AreEqual("GET request lacked required fields. Body:", ex.Message);
 		}
 
 		[Test]
@@ -138,7 +168,7 @@ namespace SmartyStreets
 			var sender = new StatusCodeSender(new MockSender(new Response(statusCode, null)));
 
 			var ex = Assert.Throws<TException>(() => sender.Send(new Request()));
-			Assert.AreEqual(expectedMessage, ex.Message);
+			Assert.AreEqual(expectedMessage + " Body:", ex.Message);
 		}
 	}
 }

--- a/src/tests/StatusCodeSenderTests.cs
+++ b/src/tests/StatusCodeSenderTests.cs
@@ -20,7 +20,48 @@ namespace SmartyStreets
 			Assert.ThrowsAsync<UnprocessableEntityException>(async () => await Send(422));
 			Assert.ThrowsAsync<TooManyRequestsException>(async () => await Send(429));
 			Assert.ThrowsAsync<InternalServerErrorException>(async () => await Send(500));
+			Assert.ThrowsAsync<BadGatewayException>(async () => await Send(502));
 			Assert.ThrowsAsync<ServiceUnavailableException>(async () => await Send(503));
+			Assert.ThrowsAsync<GatewayTimeoutException>(async () => await Send(504));
+			Assert.ThrowsAsync<SmartyException>(async () => await Send(418));
+		}
+
+		[Test]
+		public void TestFallsBackToStandardMessages()
+		{
+			AssertFallbackMessage<BadRequestException>(400,
+				"Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.");
+			AssertFallbackMessage<ForbiddenException>(403,
+				"Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.");
+			AssertFallbackMessage<TooManyRequestsException>(429,
+				"Too Many Requests: The rate limit for your account has been exceeded.");
+			AssertFallbackMessage<InternalServerErrorException>(500, "Internal Server Error.");
+			AssertFallbackMessage<BadGatewayException>(502, "Bad Gateway error.");
+			AssertFallbackMessage<ServiceUnavailableException>(503, "Service Unavailable. Try again later.");
+			AssertFallbackMessage<GatewayTimeoutException>(504,
+				"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.");
+			AssertFallbackMessage<SmartyException>(418,
+				"The server returned an unexpected HTTP status code: 418");
+		}
+
+		[Test]
+		public void TestSurfacesApiErrorMessageOn500()
+		{
+			var payload = Encoding.UTF8.GetBytes("{\"errors\":[{\"message\":\"API broke.\"}]}");
+			var sender = new StatusCodeSender(new MockSender(new Response(500, payload)));
+
+			var ex = Assert.Throws<InternalServerErrorException>(() => sender.Send(new Request()));
+			Assert.AreEqual("API broke.", ex.Message);
+		}
+
+		[Test]
+		public void TestSurfacesApiErrorMessageOnUnexpectedStatusCode()
+		{
+			var payload = Encoding.UTF8.GetBytes("{\"errors\":[{\"message\":\"API teapot message.\"}]}");
+			var sender = new StatusCodeSender(new MockSender(new Response(418, payload)));
+
+			var ex = Assert.Throws<SmartyException>(() => sender.Send(new Request()));
+			Assert.AreEqual("API teapot message.", ex.Message);
 		}
 
 		[Test]
@@ -89,6 +130,15 @@ namespace SmartyStreets
 			var inner = new MockStatusCodeSender(statusCode);
 			var sender = new StatusCodeSender(inner);
 			await sender.SendAsync(new Request());
+		}
+
+		private static void AssertFallbackMessage<TException>(int statusCode, string expectedMessage)
+			where TException : SmartyException
+		{
+			var sender = new StatusCodeSender(new MockSender(new Response(statusCode, null)));
+
+			var ex = Assert.Throws<TException>(() => sender.Send(new Request()));
+			Assert.AreEqual(expectedMessage, ex.Message);
 		}
 	}
 }

--- a/src/tests/USEnrichmentApi/ClientTests.cs
+++ b/src/tests/USEnrichmentApi/ClientTests.cs
@@ -469,7 +469,23 @@ namespace SmartyStreets.USEnrichmentApi
 			Assert.AreEqual("abc-123", this.capturingSender.Request.Headers["Etag"]);
 		}
 
-		//ETag response-capture tests (200 path; 304 path is owned by StatusCodeSenderTests since it throws upstream):
+		[Test]
+		public void Test304IsSuccessWithRefreshedEtagAndUntouchedResult()
+		{
+			var response = new Response(304, null);
+			response.HeaderInfo["Etag"] = "refreshed-etag";
+			var pipeline = new StatusCodeSender(new MockSender(response));
+			var client = new Client(pipeline, new FakeSerializer(null));
+
+			var lookup = new Business.Detail.Lookup("ABC");
+			lookup.SetRequestEtag("old-etag");
+			client.SendBusinessDetailLookup(lookup);
+
+			Assert.AreEqual("refreshed-etag", lookup.GetResponseEtag());
+			Assert.IsNull(lookup.GetResult());
+		}
+
+		//ETag response-capture tests (200 path):
 
 		[Test]
 		public void TestBusinessDetailCapturesResponseEtagOnLookup()


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- 5xx responses now extract the API message; 403/429/400 fallbacks standardized.
- Unexpected status codes previously made `SendAsync` return `null`; they now throw `SmartyException` with the standard message.

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
