### PR TITLE
Add US Autocomplete (V2) API client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ international_postal_code_api:
 us_autocomplete_pro_api:
 	dotnet run --project $(EXAMPLES_PROJECT) -- us_autocomplete_pro
 
+us_autocomplete_api:
+	dotnet run --project $(EXAMPLES_PROJECT) -- us_autocomplete
+
 us_enrichment_api:
 	dotnet run --project $(EXAMPLES_PROJECT) -- us_enrichment
 
@@ -70,11 +73,11 @@ us_zipcode_api:
 	dotnet run --project $(EXAMPLES_PROJECT) -- us_zipcode_multiple
 
 # Run all examples
-examples: international_autocomplete_api international_street_api international_postal_code_api us_autocomplete_pro_api us_enrichment_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_zipcode_api
+examples: international_autocomplete_api international_street_api international_postal_code_api us_autocomplete_pro_api us_autocomplete_api us_enrichment_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_zipcode_api
 
 ##########################################################
 release:
 	make publish
 
-.PHONY: clean compile test integrate package publish version release examples international_autocomplete_api international_street_api international_postal_code_api us_autocomplete_pro_api us_enrichment_api us_enrichment_etag_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_street_with_http_factory_api us_zipcode_api
+.PHONY: clean compile test integrate package publish version release examples international_autocomplete_api international_street_api international_postal_code_api us_autocomplete_pro_api us_autocomplete_api us_enrichment_api us_enrichment_etag_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_street_with_http_factory_api us_zipcode_api
 

--- a/src/examples/Program.cs
+++ b/src/examples/Program.cs
@@ -58,6 +58,9 @@ namespace Examples
                     case "us_autocomplete_pro":
                         USAutocompleteProExample.Run();
                         break;
+                    case "us_autocomplete":
+                        USAutocompleteExample.Run();
+                        break;
                     case "us_reverse_geo":
                         USReverseGeoExample.Run();
                         break;
@@ -92,6 +95,7 @@ namespace Examples
             InternationalPostalCodeExample.Run();
             USExtractExample.Run();
             USAutocompleteProExample.Run();
+            USAutocompleteExample.Run();
             USReverseGeoExample.Run();
             USEnrichmentPropertyExample.Run();
             USEnrichmentGeoReferenceExample.Run();

--- a/src/examples/USAutocompleteExample.cs
+++ b/src/examples/USAutocompleteExample.cs
@@ -62,10 +62,10 @@ namespace Examples
 			lookup.MaxResults = 5;
 			lookup.PreferGeolocation = GeolocateType.NONE;
 			lookup.PreferRatio = 4;
-			lookup.Source = "all";
+			lookup.Source = SourceType.ALL;
 
 			//uncomment the below line to add a custom parameter
-			//lookup.AddCustomParameter("parameter", "value");
+            //lookup.AddCustomParameter("parameter", "value");
 
             try
             {

--- a/src/examples/USAutocompleteExample.cs
+++ b/src/examples/USAutocompleteExample.cs
@@ -1,0 +1,130 @@
+namespace Examples
+{
+	using System;
+    using System.IO;
+    using SmartyStreets;
+	using SmartyStreets.USAutocompleteApi;
+
+	// This example is for US Autocomplete (V2). It has the same name as a previous product
+	// which has been deprecated since 2022, which we refer to as US Autocomplete Basic.
+	// If you are still using US Autocomplete Basic, this SDK will not work.
+	internal static class USAutocompleteExample
+	{
+		public static void Run()
+		{
+            //var key = Environment.GetEnvironmentVariable("SMARTY_AUTH_WEB");
+			//var hostname = Environment.GetEnvironmentVariable("SMARTY_WEBSITE_DOMAIN");
+			//var credentials = new SharedCredentials(key, hostname);
+
+            // We recommend storing your secret keys in environment variables.
+            var authId = Environment.GetEnvironmentVariable("SMARTY_AUTH_ID");
+			var authToken = Environment.GetEnvironmentVariable("SMARTY_AUTH_TOKEN");
+
+            using var client = new ClientBuilder(new BasicAuthCredentials(authId, authToken)).BuildUsAutocompleteApiClient();
+
+			var lookup = new Lookup("1042 W Center");
+			lookup.PreferGeolocation = "none";
+
+            try
+            {
+	            client.Send(lookup);
+            }
+            catch (SmartyException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+                return;
+            }
+            catch (IOException ex)
+            {
+                Console.WriteLine(ex.StackTrace);
+                return;
+            }
+
+            if (lookup.Result == null)
+            {
+                Console.WriteLine("No suggestions.");
+                return;
+            }
+
+            Console.WriteLine("*** Result with no filter ***");
+			Console.WriteLine();
+			foreach (var suggestion in lookup.Result)
+				Console.WriteLine(suggestion.Street + " " + suggestion.City + ", " + suggestion.State);
+
+			// Documentation for input fields can be found at:
+			// https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-request-input-fields
+
+			lookup.AddCityFilter("Denver,Aurora,CO");
+			lookup.AddCityFilter("Orem,UT");
+			lookup.AddPreferState("CO");
+			//lookup.Selected = "1042 W Center St Apt A (24) Orem UT 84057";
+			lookup.MaxResults = 5;
+			lookup.PreferGeolocation = GeolocateType.NONE;
+			lookup.PreferRatio = 4;
+			lookup.Source = "all";
+
+			//uncomment the below line to add a custom parameter
+			//lookup.AddCustomParameter("parameter", "value");
+
+            try
+            {
+                client.Send(lookup);
+            }
+            catch (SmartyException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+                return;
+            }
+            catch (IOException ex)
+            {
+                Console.WriteLine(ex.StackTrace);
+                return;
+            }
+
+            if (lookup.Result == null)
+            {
+                Console.WriteLine("No suggestions.");
+                return;
+            }
+
+            Console.WriteLine();
+			Console.WriteLine("*** Result with some filters ***");
+			string entryId = null;
+			foreach (var suggestion in lookup.Result)
+			{
+				Console.WriteLine(suggestion.Street + " " + suggestion.City + ", " + suggestion.State);
+				if (!string.IsNullOrEmpty(suggestion.EntryId))
+					entryId = suggestion.EntryId;
+			}
+
+			// Expand the secondaries of a result that has an entry_id by passing it back as the selected address.
+			if (!string.IsNullOrEmpty(entryId))
+			{
+				lookup.Selected = entryId;
+
+				try
+				{
+					client.Send(lookup);
+				}
+				catch (SmartyException ex)
+				{
+					Console.WriteLine(ex.Message);
+					Console.WriteLine(ex.StackTrace);
+					return;
+				}
+				catch (IOException ex)
+				{
+					Console.WriteLine(ex.StackTrace);
+					return;
+				}
+
+				Console.WriteLine();
+				Console.WriteLine("*** Secondaries ***");
+				foreach (var suggestion in lookup.Result)
+					Console.WriteLine(suggestion.Street + " " + suggestion.City + ", " + suggestion.State);
+			}
+		}
+	}
+}

--- a/src/examples/USAutocompleteExample.cs
+++ b/src/examples/USAutocompleteExample.cs
@@ -23,7 +23,7 @@ namespace Examples
             using var client = new ClientBuilder(new BasicAuthCredentials(authId, authToken)).BuildUsAutocompleteApiClient();
 
 			var lookup = new Lookup("1042 W Center");
-			lookup.PreferGeolocation = "none";
+			lookup.PreferGeolocation = GeolocateType.NONE;
 
             try
             {

--- a/src/examples/USAutocompleteProExample.cs
+++ b/src/examples/USAutocompleteProExample.cs
@@ -21,7 +21,7 @@
             using var client = new ClientBuilder(new BasicAuthCredentials(authId, authToken)).BuildUsAutocompleteProApiClient();
 
 			var lookup = new Lookup("1042 W Center");
-			lookup.PreferGeolocation = "none";
+			lookup.PreferGeolocation = GeolocateType.NONE;
 
             try
             { 

--- a/src/sdk/ClientBuilder.cs
+++ b/src/sdk/ClientBuilder.cs
@@ -33,6 +33,7 @@ namespace SmartyStreets
         private const string InternationalAutocompleteApiUrl = "https://international-autocomplete.api.smarty.com/v2/lookup";
         private const string InternationalPostalCodeApiUrl = "https://international-postal-code.api.smarty.com/lookup";
         private const string UsAutocompleteProApiUrl = "https://us-autocomplete-pro.api.smarty.com/lookup";
+        private const string UsAutocompleteApiUrl = "https://us-autocomplete.api.smarty.com/v2/lookup";
         private const string UsExtractApiUrl = "https://us-extract.api.smarty.com/";
         private const string UsStreetApiUrl = "https://us-street.api.smarty.com/street-address";
         private const string UsZipCodeApiUrl = "https://us-zipcode.api.smarty.com/lookup";
@@ -245,6 +246,12 @@ namespace SmartyStreets
         {
             this.EnsureURLPrefixNotNull(UsAutocompleteProApiUrl);
             return new USAutocompleteProApi.Client(this.BuildSender(), this.serializer);
+        }
+
+        public USAutocompleteApi.Client BuildUsAutocompleteApiClient()
+        {
+            this.EnsureURLPrefixNotNull(UsAutocompleteApiUrl);
+            return new USAutocompleteApi.Client(this.BuildSender(), this.serializer);
         }
 
         public USExtractApi.Client BuildUsExtractApiClient()

--- a/src/sdk/USAutocompleteApi/Client.cs
+++ b/src/sdk/USAutocompleteApi/Client.cs
@@ -1,0 +1,101 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+	using System;
+	using System.Collections;
+	using System.IO;
+	using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    ///     This client sends lookups to the SmartyStreets US Autocomplete API,
+    ///     and attaches the results to the appropriate Lookup objects.
+    /// </summary>
+    public class Client : IUSAutocompleteClient
+    {
+	    private bool senderWasDisposed;
+		private readonly ISender sender;
+		private readonly ISerializer serializer;
+
+		public Client(ISender sender, ISerializer serializer)
+		{
+			this.sender = sender;
+			this.serializer = serializer;
+		}
+
+		public void Send(Lookup lookup)
+		{
+			SendAsync(lookup).GetAwaiter().GetResult();
+		}
+
+		public async Task SendAsync(Lookup lookup)
+		{
+			if (lookup == null)
+				throw new ArgumentNullException("lookup");
+
+			if (string.IsNullOrEmpty(lookup?.Search))
+				throw new SmartyException("Send() must be passed a Lookup with the search field set.");
+
+			var request = BuildRequest(lookup);
+
+			var response = await this.sender.SendAsync(request);
+
+			using (var payloadStream = new MemoryStream(response.Payload))
+			{
+				var result = this.serializer.Deserialize<Result>(payloadStream) ?? new Result();
+				var suggestions = result.Suggestions;
+				lookup.Result = suggestions;
+			}
+		}
+
+		private static Request BuildRequest(Lookup lookup)
+		{
+			var request = new Request();
+
+			request.SetParameter("search", lookup.Search);
+			request.SetParameter("max_results", lookup.GetMaxSuggestionsStringIfSet());
+			request.SetParameter("include_only_cities", BuildFilterString(lookup.CityFilter));
+			request.SetParameter("include_only_states", BuildFilterString(lookup.StateFilter));
+			request.SetParameter("include_only_zip_codes", BuildFilterString(lookup.ZIPFilter));
+			request.SetParameter("exclude_states", BuildFilterString(lookup.ExcludeStates));
+			request.SetParameter("prefer_cities", BuildFilterString(lookup.PreferCities));
+			request.SetParameter("prefer_states", BuildFilterString(lookup.PreferStates));
+			request.SetParameter("prefer_zip_codes", BuildFilterString(lookup.PreferZIPCodes));
+			request.SetParameter("prefer_ratio", lookup.GetPreferRatioStringIfSet());
+			request.SetParameter("prefer_geolocation", lookup.PreferGeolocation);
+			request.SetParameter("selected", lookup.Selected);
+			request.SetParameter("exclude", lookup.Exclude);
+			request.SetParameter("source", lookup.Source);
+
+			foreach (KeyValuePair<string, string> line in lookup.CustomParamDict) {
+				request.SetParameter(line.Key, line.Value);
+			}
+
+			return request;
+		}
+
+		private static string BuildFilterString(ICollection list)
+		{
+			if (list.Count == 0)
+				return null;
+
+			var filterList = "";
+
+			foreach (string item in list)
+				filterList += item + ";";
+
+			if (filterList.EndsWith(";"))
+				filterList = filterList.Substring(0, filterList.Length - 1);
+
+			return filterList;
+		}
+
+		public void Dispose()
+		{
+			if (!this.senderWasDisposed)
+			{
+				this.sender.Dispose();
+				this.senderWasDisposed = true;
+			}
+		}
+	}
+}

--- a/src/sdk/USAutocompleteApi/Client.cs
+++ b/src/sdk/USAutocompleteApi/Client.cs
@@ -63,7 +63,7 @@ namespace SmartyStreets.USAutocompleteApi
 			request.SetParameter("prefer_ratio", lookup.GetPreferRatioStringIfSet());
 			request.SetParameter("prefer_geolocation", lookup.PreferGeolocation);
 			request.SetParameter("selected", lookup.Selected);
-			request.SetParameter("exclude", lookup.Exclude);
+			request.SetParameter("exclude", BuildFilterString(lookup.Exclude, ","));
 			request.SetParameter("source", lookup.Source);
 
 			foreach (KeyValuePair<string, string> line in lookup.CustomParamDict) {
@@ -75,16 +75,21 @@ namespace SmartyStreets.USAutocompleteApi
 
 		private static string BuildFilterString(ICollection list)
 		{
+			return BuildFilterString(list, ";");
+		}
+
+		private static string BuildFilterString(ICollection list, string separator)
+		{
 			if (list.Count == 0)
 				return null;
 
 			var filterList = "";
 
 			foreach (string item in list)
-				filterList += item + ";";
+				filterList += item + separator;
 
-			if (filterList.EndsWith(";"))
-				filterList = filterList.Substring(0, filterList.Length - 1);
+			if (filterList.EndsWith(separator))
+				filterList = filterList.Substring(0, filterList.Length - separator.Length);
 
 			return filterList;
 		}

--- a/src/sdk/USAutocompleteApi/GeolocateType.cs
+++ b/src/sdk/USAutocompleteApi/GeolocateType.cs
@@ -1,0 +1,12 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+	/// <summary>
+	///     This class corresponds to the geolocate_precision field in the US Autocomplete API
+	/// </summary>
+	/// <remarks>See "https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-request-input-fields"</remarks>
+	public static class GeolocateType
+	{
+		public const string CITY = "city";
+		public const string NONE = "none";
+	}
+}

--- a/src/sdk/USAutocompleteApi/IUSAutocompleteClient.cs
+++ b/src/sdk/USAutocompleteApi/IUSAutocompleteClient.cs
@@ -1,0 +1,8 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+    // marker interface for easy dependency injection and unit test mocking
+    public interface IUSAutocompleteClient : IClient<Lookup>
+    {
+
+    }
+}

--- a/src/sdk/USAutocompleteApi/Lookup.cs
+++ b/src/sdk/USAutocompleteApi/Lookup.cs
@@ -29,7 +29,7 @@ namespace SmartyStreets.USAutocompleteApi
 		public double PreferRatio { get; set; }
 		public string PreferGeolocation { get; set; }
 		public string Selected { get; set; }
-		public string Exclude { get; set; }
+		public ArrayList Exclude { get; set; }
 		public string Source { get; set; }
 		public Dictionary<string, string> CustomParamDict = new Dictionary<string, string>{};
 
@@ -51,6 +51,7 @@ namespace SmartyStreets.USAutocompleteApi
 			this.PreferCities = new ArrayList();
 			this.PreferStates = new ArrayList();
 			this.PreferZIPCodes = new ArrayList();
+			this.Exclude = new ArrayList();
 			this.PreferRatio = PREFER_RATIO_DEFAULT;
 			this.PreferGeolocation = GeolocateType.CITY;
 		}
@@ -112,6 +113,11 @@ namespace SmartyStreets.USAutocompleteApi
 		{
 			this.PreferGeolocation = GeolocateType.NONE;
 			this.PreferZIPCodes.Add(zipcode);
+		}
+
+		public void AddExclude(string excludeType)
+		{
+			this.Exclude.Add(excludeType);
 		}
 
 		public void AddCustomParameter(string parameter, string value) {

--- a/src/sdk/USAutocompleteApi/Lookup.cs
+++ b/src/sdk/USAutocompleteApi/Lookup.cs
@@ -1,0 +1,121 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+	using System.Collections;
+	using System.Collections.Generic;
+
+	/// <summary>
+	///     In addition to holding all of the input data for this lookup, this class also
+	///     will contain the result of the lookup after it comes back from the API.
+	/// </summary>
+	/// <remarks>
+	///     See "https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-request-input-fields"
+	/// </remarks>
+	public class Lookup
+	{
+		#region [ Fields ]
+
+		private const double PREFER_RATIO_DEFAULT = 3;
+		private const int MAX_RESULTS_DEFAULT = 10;
+		public Suggestion[] Result { get; set; }
+		public string Search { get; set; }
+		public int MaxResults { get; set; }
+		public ArrayList CityFilter { get; set; }
+		public ArrayList StateFilter { get; set; }
+		public ArrayList ZIPFilter { get; set; }
+		public ArrayList ExcludeStates { get; set; }
+		public ArrayList PreferCities { get; set; }
+		public ArrayList PreferStates { get; set; }
+		public ArrayList PreferZIPCodes { get; set; }
+		public double PreferRatio { get; set; }
+		public string PreferGeolocation { get; set; }
+		public string Selected { get; set; }
+		public string Exclude { get; set; }
+		public string Source { get; set; }
+		public Dictionary<string, string> CustomParamDict = new Dictionary<string, string>{};
+
+		#endregion
+
+		#region [ Constructors ]
+
+		/// <remarks>
+		///     If you use this constructor, don't forget to set the Search field. It is required.
+		/// </remarks>
+		/// >
+		public Lookup()
+		{
+			this.MaxResults = MAX_RESULTS_DEFAULT;
+			this.CityFilter = new ArrayList();
+			this.StateFilter = new ArrayList();
+			this.ZIPFilter = new ArrayList();
+			this.ExcludeStates = new ArrayList();
+			this.PreferCities = new ArrayList();
+			this.PreferStates = new ArrayList();
+			this.PreferZIPCodes = new ArrayList();
+			this.PreferRatio = PREFER_RATIO_DEFAULT;
+			this.PreferGeolocation = GeolocateType.CITY;
+		}
+
+		/// <param name="search">The beginning of an address.</param>
+		public Lookup(string search) : this()
+		{
+			this.Search = search;
+		}
+
+		internal string GetPreferRatioStringIfSet()
+		{
+			if (this.PreferRatio.Equals(PREFER_RATIO_DEFAULT))
+				return null;
+			return this.PreferRatio.ToString();
+		}
+
+		internal string GetMaxSuggestionsStringIfSet()
+		{
+			if (this.MaxResults.Equals(MAX_RESULTS_DEFAULT))
+				return null;
+			return this.MaxResults.ToString();
+		}
+
+		#endregion
+
+		public void AddCityFilter(string city)
+		{
+			this.CityFilter.Add(city);
+		}
+
+		public void AddStateFilter(string stateAbbreviation)
+		{
+			this.StateFilter.Add(stateAbbreviation);
+		}
+
+		public void AddZIPFilter(string zipcode)
+		{
+			this.PreferGeolocation = GeolocateType.NONE;
+			this.ZIPFilter.Add(zipcode);
+		}
+
+		public void AddExclusion(string stateAbbreviation)
+		{
+			this.ExcludeStates.Add(stateAbbreviation);
+		}
+
+		public void AddPreferCity(string city)
+		{
+			this.PreferCities.Add(city);
+		}
+
+		public void AddPreferState(string stateAbbreviation)
+		{
+			this.PreferStates.Add(stateAbbreviation);
+		}
+
+		public void AddPreferZIP(string zipcode)
+		{
+			this.PreferGeolocation = GeolocateType.NONE;
+			this.PreferZIPCodes.Add(zipcode);
+		}
+
+		public void AddCustomParameter(string parameter, string value) {
+			CustomParamDict.Add(parameter, value);
+		}
+	}
+}

--- a/src/sdk/USAutocompleteApi/Result.cs
+++ b/src/sdk/USAutocompleteApi/Result.cs
@@ -1,0 +1,11 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+	using System.Runtime.Serialization;
+
+	[DataContract]
+	public class Result
+	{
+		[DataMember(Name = "suggestions")]
+		public Suggestion[] Suggestions { get; set; }
+	}
+}

--- a/src/sdk/USAutocompleteApi/SourceType.cs
+++ b/src/sdk/USAutocompleteApi/SourceType.cs
@@ -1,0 +1,11 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+	/// <summary>
+	///     This class corresponds to the source field in the US Autocomplete API
+	/// </summary>
+	public static class SourceType
+	{
+		public const string ALL = "all";
+		public const string POSTAL = "postal";
+	}
+}

--- a/src/sdk/USAutocompleteApi/Suggestion.cs
+++ b/src/sdk/USAutocompleteApi/Suggestion.cs
@@ -1,0 +1,36 @@
+namespace SmartyStreets.USAutocompleteApi
+{
+	using System.Runtime.Serialization;
+
+	/// <remarks>
+	///     See "https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-response-status"
+	/// </remarks>
+	/// >
+	[DataContract]
+	public class Suggestion
+	{
+		[DataMember(Name = "smarty_key")]
+		public string SmartyKey { get; set; }
+
+		[DataMember(Name = "entry_id")]
+		public string EntryId { get; set; }
+
+		[DataMember(Name = "street_line")]
+		public string Street { get; set; }
+
+		[DataMember(Name = "secondary")]
+		public string Secondary { get; set; }
+
+		[DataMember(Name = "city")]
+		public string City { get; set; }
+
+		[DataMember(Name = "state")]
+		public string State { get; set; }
+
+		[DataMember(Name = "zipcode")]
+		public string ZIPCode { get; set; }
+
+		[DataMember(Name = "entries")]
+		public string Entries { get; set; }
+	}
+}

--- a/src/sdk/USAutocompleteApi/Suggestion.cs
+++ b/src/sdk/USAutocompleteApi/Suggestion.cs
@@ -31,6 +31,9 @@ namespace SmartyStreets.USAutocompleteApi
 		public string ZIPCode { get; set; }
 
 		[DataMember(Name = "entries")]
-		public string Entries { get; set; }
+		public int Entries { get; set; }
+
+		[DataMember(Name = "source")]
+        public string Source { get; set; }
 	}
 }

--- a/src/tests/USAutocompleteApi/ClientTest.cs
+++ b/src/tests/USAutocompleteApi/ClientTest.cs
@@ -42,7 +42,7 @@ namespace SmartyStreets.USAutocomplete
 			lookup.PreferRatio = 4;
 			lookup.PreferGeolocation = GeolocateType.CITY;
 			lookup.Selected = "selectedAddress";
-			lookup.Exclude = "excludedAddress";
+			lookup.AddExclude("excludedAddress");
 			lookup.Source = SourceType.ALL;
 
 			client.Send(lookup);
@@ -91,11 +91,12 @@ namespace SmartyStreets.USAutocomplete
 			var serializer = new FakeSerializer(null);
 			var client = new Client(this.sender, serializer);
 			var lookup = new Lookup("1");
-			lookup.Exclude = "excludedAddress";
+			lookup.AddExclude("excludedAddress");
+			lookup.AddExclude("excludedAddress2");
 
 			client.Send(lookup);
 
-			Assert.AreEqual("http://localhost/?search=1&prefer_geolocation=city&exclude=excludedAddress", this.capturingSender.Request.GetUrl());
+			Assert.AreEqual("http://localhost/?search=1&prefer_geolocation=city&exclude=excludedAddress%2CexcludedAddress2", this.capturingSender.Request.GetUrl());
 		}
 	}
 }

--- a/src/tests/USAutocompleteApi/ClientTest.cs
+++ b/src/tests/USAutocompleteApi/ClientTest.cs
@@ -43,13 +43,46 @@ namespace SmartyStreets.USAutocomplete
 			lookup.PreferGeolocation = GeolocateType.CITY;
 			lookup.Selected = "selectedAddress";
 			lookup.Exclude = "excludedAddress";
-			lookup.Source = "all";
+			lookup.Source = SourceType.ALL;
 
 			client.Send(lookup);
 
 			Assert.AreEqual(
 				"http://localhost/?search=1&max_results=5&include_only_cities=city&include_only_states=state&exclude_states=excludedState&prefer_cities=preferCity&prefer_states=preferState&prefer_ratio=4&prefer_geolocation=city&selected=selectedAddress&exclude=excludedAddress&source=all",
 				this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestSourceNotIncludedWhenNotSet()
+		{
+			var client = new Client(this.sender, new FakeSerializer(null));
+			var lookup = new Lookup("test");
+
+			client.Send(lookup);
+
+			StringAssert.DoesNotContain("source", this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestSourceAll()
+		{
+			var client = new Client(this.sender, new FakeSerializer(null));
+			var lookup = new Lookup("test") { Source = SourceType.ALL };
+
+			client.Send(lookup);
+
+			Assert.AreEqual("http://localhost/?search=test&prefer_geolocation=city&source=all", this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestSourcePostal()
+		{
+			var client = new Client(this.sender, new FakeSerializer(null));
+			var lookup = new Lookup("test") { Source = SourceType.POSTAL };
+
+			client.Send(lookup);
+
+			Assert.AreEqual("http://localhost/?search=test&prefer_geolocation=city&source=postal", this.capturingSender.Request.GetUrl());
 		}
 
 		[Test]

--- a/src/tests/USAutocompleteApi/ClientTest.cs
+++ b/src/tests/USAutocompleteApi/ClientTest.cs
@@ -1,0 +1,68 @@
+namespace SmartyStreets.USAutocomplete
+{
+	using USAutocompleteApi;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class ClientTests
+	{
+		private RequestCapturingSender capturingSender;
+		private URLPrefixSender sender;
+
+		[SetUp]
+		public void Setup()
+		{
+			this.capturingSender = new RequestCapturingSender();
+			this.sender = new URLPrefixSender("http://localhost/", this.capturingSender);
+		}
+
+		[Test]
+		public void TestSendingSearchOnlyLookup()
+		{
+			var serializer = new FakeSerializer(null);
+			var client = new Client(this.sender, serializer);
+
+			client.Send(new Lookup("1"));
+
+			Assert.AreEqual("http://localhost/?search=1&prefer_geolocation=city", this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestSendingFullyPopulatedLookup()
+		{
+			var serializer = new FakeSerializer(null);
+			var client = new Client(this.sender, serializer);
+			var lookup = new Lookup("1");
+			lookup.MaxResults = 5;
+			lookup.AddCityFilter("city");
+			lookup.AddStateFilter("state");
+			lookup.AddExclusion("excludedState");
+			lookup.AddPreferCity("preferCity");
+			lookup.AddPreferState("preferState");
+			lookup.PreferRatio = 4;
+			lookup.PreferGeolocation = GeolocateType.CITY;
+			lookup.Selected = "selectedAddress";
+			lookup.Exclude = "excludedAddress";
+			lookup.Source = "all";
+
+			client.Send(lookup);
+
+			Assert.AreEqual(
+				"http://localhost/?search=1&max_results=5&include_only_cities=city&include_only_states=state&exclude_states=excludedState&prefer_cities=preferCity&prefer_states=preferState&prefer_ratio=4&prefer_geolocation=city&selected=selectedAddress&exclude=excludedAddress&source=all",
+				this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestSendingExclude()
+		{
+			var serializer = new FakeSerializer(null);
+			var client = new Client(this.sender, serializer);
+			var lookup = new Lookup("1");
+			lookup.Exclude = "excludedAddress";
+
+			client.Send(lookup);
+
+			Assert.AreEqual("http://localhost/?search=1&prefer_geolocation=city&exclude=excludedAddress", this.capturingSender.Request.GetUrl());
+		}
+	}
+}


### PR DESCRIPTION
- New US Autocomplete module: Lookup, Client, Suggestion (+ Result/serializer where applicable)
- ClientBuilder method to build the client
- Unit tests, plus an example demonstrating filtered lookups and secondary expansion (capture an entry_id, pass it back as `selected`)