### PR TITLE
Make International Street Language a real enum, case-insensitive

### DIFF
--- a/src/sdk/InternationalStreetApi/Client.cs
+++ b/src/sdk/InternationalStreetApi/Client.cs
@@ -52,8 +52,8 @@
 			request.SetParameter("input_id", lookup.InputId);
 			request.SetParameter("country", lookup.Country);
 			request.SetParameter("geocode", lookup.Geocode ? lookup.Geocode.ToString().ToLower() : null);
-			if (lookup.Language != null)
-				request.SetParameter("language", lookup.Language);
+			if (lookup.Language.HasValue)
+				request.SetParameter("language", lookup.Language.Value.ToWireValue());
 			request.SetParameter("freeform", lookup.Freeform);
 			request.SetParameter("address1", lookup.Address1);
 			request.SetParameter("address2", lookup.Address2);

--- a/src/sdk/InternationalStreetApi/LanguageMode.cs
+++ b/src/sdk/InternationalStreetApi/LanguageMode.cs
@@ -1,13 +1,46 @@
-﻿namespace SmartyStreets.InternationalStreetApi
+namespace SmartyStreets.InternationalStreetApi
 {
+	using System;
+
 	/// <summary>
-	///     When not set, the output language will match the language of the input values. When set to NATIVE the
-	///     results will always be in the language of the output country. When set to LATIN the results
+	///     When not set, the output language will match the language of the input values. When set to Native the
+	///     results will always be in the language of the output country. When set to Latin the results
 	///     will always be provided using a Latin character set.
 	/// </summary>
-	public static class LanguageMode
+	public enum LanguageMode
 	{
-		public const string NATIVE = "native";
-		public const string LATIN = "latin";
+		Native,
+		Latin
+	}
+
+	public static class LanguageModeExtensions
+	{
+		internal static string ToWireValue(this LanguageMode mode)
+		{
+			switch (mode)
+			{
+				case LanguageMode.Native:
+					return "native";
+				case LanguageMode.Latin:
+					return "latin";
+				default:
+					throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+			}
+		}
+
+		/// <summary>
+		///     Resolves a value (eg. from external config) into a LanguageMode, matching "native"/"latin"
+		///     regardless of case.
+		/// </summary>
+		public static LanguageMode FromValue(string value)
+		{
+			if (string.Equals(value, "native", StringComparison.OrdinalIgnoreCase))
+				return LanguageMode.Native;
+			if (string.Equals(value, "latin", StringComparison.OrdinalIgnoreCase))
+				return LanguageMode.Latin;
+
+			throw new UnprocessableEntityException(
+				"invalid Language value; must be unset, 'native', or 'latin' (case-insensitive)");
+		}
 	}
 }

--- a/src/sdk/InternationalStreetApi/Lookup.cs
+++ b/src/sdk/InternationalStreetApi/Lookup.cs
@@ -25,9 +25,9 @@
 		public string Country { get; set; }
 
 		/// <remarks>
-		///     May be set to LanguageMode.NATIVE or LanguageMode.LATIN
+		///     May be set to LanguageMode.Native or LanguageMode.Latin
 		/// </remarks>
-		public string Language { get; set; }
+		public LanguageMode? Language { get; set; }
 
 		/// <summary>
 		///     The entire address except the country, which should be input using the Country field.

--- a/src/tests/InternationalStreet/ClientTests.cs
+++ b/src/tests/InternationalStreet/ClientTests.cs
@@ -45,7 +45,7 @@
 			    InputId = "1234",
 				Country = "0",
 				Geocode = true,
-				Language = LanguageMode.NATIVE,
+				Language = LanguageMode.Native,
 				Freeform = "1",
 				Address1 = "2",
 				Address2 = "3",
@@ -61,6 +61,36 @@
 			client.Send(lookup);
 
 			Assert.AreEqual(expectedUrl, this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestSendingLookupWithLanguageParsedFromMixedCaseValue()
+		{
+			var serializer = new FakeSerializer(null);
+			var client = new Client(this.sender, serializer);
+			var lookup = new Lookup
+			{
+				Country = "0",
+				Freeform = "1",
+				Language = LanguageModeExtensions.FromValue("Latin")
+			};
+
+			client.Send(lookup);
+
+			Assert.AreEqual("http://localhost/?country=0&language=latin&freeform=1", this.capturingSender.Request.GetUrl());
+		}
+
+		[Test]
+		public void TestLanguageModeParseResolvesMixedCase()
+		{
+			Assert.AreEqual(LanguageMode.Latin, LanguageModeExtensions.FromValue("Latin"));
+			Assert.AreEqual(LanguageMode.Native, LanguageModeExtensions.FromValue("NATIVE"));
+		}
+
+		[Test]
+		public void TestLanguageModeParseRejectsInvalidValue()
+		{
+			Assert.Throws<UnprocessableEntityException>(() => LanguageModeExtensions.FromValue("Klingon"));
 		}
 
 		[Test]


### PR DESCRIPTION
Lookup.Language is now LanguageMode? (a real enum with Native/Latin members) instead of a plain string, so invalid values can no longer be assigned. Added LanguageModeExtensions.FromValue() to resolve a raw string case-insensitively (eg. "Latin", "NATIVE") for callers building the value from external input.